### PR TITLE
Fix cirs2obs segfault

### DIFF
--- a/src/cirs2obs.cpp
+++ b/src/cirs2obs.cpp
@@ -72,10 +72,10 @@ std::map<std::string, double> defaultoptions()
     
     // Set the current time as the default date for query
     time_t current_time = time(NULL) ;
-    struct tm * timeinfo;
-    gmtime_r(&current_time, timeinfo) ;
-    double dayfrac = (timeinfo->tm_hour + (timeinfo->tm_min/60.0) + ((timeinfo->tm_sec)/3600.0))/24.0 ;
-    CEDate date({timeinfo->tm_year+1900.0, timeinfo->tm_mon+1.0, 1.0*timeinfo->tm_mday, dayfrac}) ;
+    struct tm timeinfo;
+    gmtime_r(&current_time, &timeinfo) ;
+    double dayfrac = (timeinfo.tm_hour + (timeinfo.tm_min/60.0) + ((timeinfo.tm_sec)/3600.0))/24.0 ;
+    CEDate date({timeinfo.tm_year+1900.0, timeinfo.tm_mon+1.0, 1.0*timeinfo.tm_mday, dayfrac}) ;
     
     options["juliandate"] = date.JD() ;
     

--- a/src/gal2obs.cpp
+++ b/src/gal2obs.cpp
@@ -72,10 +72,10 @@ std::map<std::string, double> defaultoptions()
     
     // Set the current time as the default date for query
     time_t current_time = time(NULL) ;
-    struct tm * timeinfo;
-    gmtime_r(&current_time, timeinfo) ;
-    double dayfrac = (timeinfo->tm_hour + (timeinfo->tm_min/60.0) + ((timeinfo->tm_sec)/3600.0))/24.0 ;
-    CEDate date({timeinfo->tm_year+1900.0, timeinfo->tm_mon+1.0, 1.0*timeinfo->tm_mday, dayfrac}) ;
+    struct tm timeinfo;
+    gmtime_r(&current_time, &timeinfo) ;
+    double dayfrac = (timeinfo.tm_hour + (timeinfo.tm_min/60.0) + ((timeinfo.tm_sec)/3600.0))/24.0 ;
+    CEDate date({timeinfo.tm_year+1900.0, timeinfo.tm_mon+1.0, 1.0*timeinfo.tm_mday, dayfrac}) ;
     
     options["juliandate"] = date.JD() ;
     


### PR DESCRIPTION
Fixes the segfault seen in cirs2obs resulting from changing to reentrant `gmtime_r` method. Also fixes similar issue seen in gal2obs. Fixes #6.