### PR TITLE
Fix icrs2obs

### DIFF
--- a/include/CECoordinates.h
+++ b/include/CECoordinates.h
@@ -29,6 +29,7 @@
 #include "CEDate.h"
 #include "CENamespace.h"
 //#include "CEObserver.h"
+#include "CEException.h"
 
 // SOFA HEADER
 #include "sofa.h"

--- a/include/CEException.h
+++ b/include/CEException.h
@@ -1,0 +1,91 @@
+/***************************************************************************
+ *  CEException.cpp: CppEphem                                                   *
+ * ----------------------------------------------------------------------- *
+ *  Copyright © 2019 JCardenzana                                           *
+ * ----------------------------------------------------------------------- *
+ *                                                                         *
+ *  This program is free software: you can redistribute it and/or modify   *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation, either version 3 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  This program is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *  You should have received a copy of the GNU General Public License      *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <exception>
+#include <execinfo.h>
+
+class CEExceptionHandler : public std::exception {
+public:
+    CEExceptionHandler() {
+        // get void*'s for all entries on the stack
+        void *array[100];
+        int size = backtrace(array, 100);
+
+        // print out all the frames to stderr
+        char** bcktrace = backtrace_symbols(array, size);
+
+        std::cerr << "Exception encountered. Printing backtrace..." << std::endl;
+        for (size_t i = 0; i < size; i++) {
+            std::cerr << std::string(bcktrace[i]) << std::endl;
+        }
+    }
+    CEExceptionHandler(const std::string& origin,
+                       const std::string& message,
+                       const std::string& type = "<no type>");
+    virtual ~CEExceptionHandler() throw() {}
+    virtual const char* what() const noexcept;
+
+protected:
+    std::string origin_;
+    std::string type_;
+    std::string message_;
+};
+
+
+/***********************************************************************//**
+ * @class CEException
+ *
+ * Interface for exceptions in CppEphem
+ ***************************************************************************/
+class CEException : public CEExceptionHandler {
+public:
+
+    // When a value is not valid
+    class invalid_value : public CEExceptionHandler {
+        public:
+            invalid_value(const std::string& origin,
+                          const std::string& message);
+    };
+
+    /* ----------------------------------------------------------- *
+     *             EXCEPTIONS RELATED TO SOFA ERRORS
+     * ----------------------------------------------------------- */
+
+    // When an exception happens inside a sofa method
+    class sofa_exception : public CEExceptionHandler {
+        public:
+            sofa_exception(const std::string& origin,
+                           const std::string& sofa_method,
+                           const std::string& message);
+    };
+
+    // When a particular error code is produced by a sofa method
+    class sofa_error : public CEExceptionHandler {
+        public: 
+            sofa_error(const std::string& origin,
+                       const std::string& sofa_method,
+                       const int&         errcode,
+                       const std::string& message);
+    };
+};

--- a/src/CECoordinates.cpp
+++ b/src/CECoordinates.cpp
@@ -200,11 +200,11 @@ int CECoordinates::CIRS2Observed(double ra, double dec,
     }
     
     // Setup the observed RA, Dec and hour_angle variables
-    double *temp_ra, *temp_dec, *temp_hour_angle ;
+    double temp_ra, temp_dec, temp_hour_angle ;
     // If values were passed, point these variables at the passed ones
-    if (observed_ra != nullptr) temp_ra = observed_ra ;
-    if (observed_dec != nullptr) temp_dec = observed_dec ;
-    if (hour_angle != nullptr) temp_hour_angle = hour_angle ;
+    if (observed_ra  == nullptr) observed_ra  = &temp_ra;
+    if (observed_dec == nullptr) observed_dec = &temp_dec;
+    if (hour_angle   == nullptr) hour_angle   = &temp_hour_angle;
     
     int err_code = CIRS2Observed(ra, dec,
                                  az, zen,
@@ -219,15 +219,17 @@ int CECoordinates::CIRS2Observed(double ra, double dec,
                                  observer.Date()->xpolar(),
                                  observer.Date()->xpolar(),
                                  wavelength,
-                                 temp_ra, temp_dec, temp_hour_angle) ;
+                                 observed_ra, 
+                                 observed_dec, 
+                                 hour_angle) ;
     
     // Now convert back to degrees if that's what we were passed
     if (angle_type == CEAngleType::DEGREES) {
         *az              *= DR2D ;
         *zen             *= DR2D ;
-        *temp_ra         *= DR2D ;
-        *temp_dec        *= DR2D ;
-        *temp_hour_angle *= DR2D ;
+        *observed_ra     *= DR2D ;
+        *observed_dec    *= DR2D ;
+        *hour_angle      *= DR2D ;
     }
     
     return err_code ;
@@ -654,14 +656,17 @@ int CECoordinates::CIRS2Observed(double ra, double dec,
                                  double *hour_angle)
 {
     // Setup the observed RA, Dec and hour_angle variables
-    double *temp_ra, *temp_dec, *temp_hour_angle ;
-    // If values were passed, point these variables at the passed ones
-    if (observed_ra != nullptr) temp_ra = observed_ra ;
-    if (observed_dec != nullptr) temp_dec = observed_dec ;
-    if (hour_angle != nullptr) temp_hour_angle = hour_angle ;
+    double temp_ra, temp_dec, temp_hour_angle ;
+
+    // If values were not passed, point them at the temporary ones
+    if (observed_ra  == nullptr) observed_ra  = &temp_ra;
+    if (observed_dec == nullptr) observed_dec = &temp_dec;
+    if (hour_angle   == nullptr) hour_angle   = &temp_hour_angle;
 
     // Call the necessary sofa method
-    int err_code = iauAtio13(ra, dec,
+    int err_code = 0;
+    try {
+        err_code = iauAtio13(ra, dec,
                              julian_date, 0.0,
                              dut1,
                              longitude,
@@ -673,7 +678,14 @@ int CECoordinates::CIRS2Observed(double ra, double dec,
                              relative_humidity,
                              wavelength_um,
                              az, zen,
-                             temp_hour_angle, temp_dec, temp_ra) ;
+                             hour_angle, 
+                             observed_dec, 
+                             observed_ra) ;
+    } catch (std::exception &e) {
+        throw CEException::sofa_exception("CECoordinates::CIRS2Observed",
+                                          "iauAtio13",
+                                          e.what());
+    }
 
     return err_code ;
 }
@@ -766,10 +778,11 @@ int CECoordinates::ICRS2Observed(double ra, double dec,
                                  double *hour_angle)
 {
     // Setup the observed RA, Dec and hour_angle variables
-    double *temp_ra, *temp_dec ;
+    double temp_ra, temp_dec, temp_hour_angle ;
     // If values were passed, point these variables at the passed ones
-    if (observed_ra != nullptr) temp_ra = observed_ra ;
-    if (observed_dec != nullptr) temp_dec = observed_dec ;
+    if (observed_ra  == nullptr) observed_ra  = &temp_ra;
+    if (observed_dec == nullptr) observed_dec = &temp_dec;
+    if (hour_angle   == nullptr) hour_angle   = &temp_hour_angle;
     
     // First convert the ICRS coordinats to CIRS coordinates
     CEDate date(julian_date, CEDateType::JD) ;
@@ -787,12 +800,12 @@ int CECoordinates::ICRS2Observed(double ra, double dec,
                                  relative_humidity,
                                  dut1, xp, yp,
                                  wavelength_um,
-                                 temp_ra,
-                                 temp_dec,
+                                 observed_ra,
+                                 observed_dec,
                                  hour_angle) ;
     
     // Convert the apparent CIRS RA,Dec to ICRS RA,Dec
-    CIRS2ICRS(*temp_ra, *temp_dec, temp_ra, temp_dec, date, CEAngleType::RADIANS) ;
+    CIRS2ICRS(*observed_ra, *observed_dec, observed_ra, observed_dec, date, CEAngleType::RADIANS) ;
     
     return err_code ;
 }
@@ -888,11 +901,11 @@ int CECoordinates::Galactic2Observed(double glon, double glat,
                                      double *hour_angle)
 {
     // Setup the observed RA, Dec and hour_angle variables
-    double *temp_glon, *temp_glat ;
-    double temp_ra, temp_dec, temp_ha ;
+    double temp_glon, temp_glat ;
+    double temp_ra, temp_dec, temp_hour_angle ;
     // If values were passed, point these variables at the passed ones
-    if (observed_glon != nullptr) temp_glon = observed_glon ;
-    if (observed_glat != nullptr) temp_glat = observed_glat ;
+    if (observed_glon == nullptr) observed_glon = &temp_glon;
+    if (observed_glat == nullptr) observed_glat = &temp_glat;
     
     // Convert GALACTIC to ICRS
     double ra(0.0), dec(0.0) ;
@@ -913,10 +926,10 @@ int CECoordinates::Galactic2Observed(double glon, double glat,
                                  wavelength,
                                  &temp_ra,
                                  &temp_dec,
-                                 &temp_ha) ;
+                                 &temp_hour_angle) ;
 
     // Convert the apparent RA,Dec to galactic longitude,latitude
-    CIRS2Galactic(temp_ra, temp_dec, temp_glon, temp_glat, date) ;
+    CIRS2Galactic(temp_ra, temp_dec, &temp_glon, &temp_glat, date) ;
     
     return err_code ;
 }
@@ -1014,14 +1027,14 @@ CECoordinates CECoordinates::GetObservedCoords(double julian_date,
                       julian_date, longitude, latitude,
                       elevation_m, pressure_hPa, temperature_celsius,
                       relative_humidity, dut1, xp, yp, wavelength,
-                      &observed1, &observed2) ;
+                      &observed1, &observed2, &observed3) ;
     } else if (coord_type_ == CECoordinateType::GALACTIC) {
         // Convert Galactic to Observed
         Galactic2Observed(xcoord_, ycoord_, &azimuth, &zenith,
                           julian_date, longitude, latitude,
                           elevation_m, pressure_hPa, temperature_celsius,
                           relative_humidity, dut1, xp, yp, wavelength,
-                          &observed1, &observed2) ;
+                          &observed1, &observed2, &observed3) ;
     }
     
     // Create the CECoordinates object to be returned

--- a/src/CECoordinates.cpp
+++ b/src/CECoordinates.cpp
@@ -935,7 +935,7 @@ int CECoordinates::Galactic2Observed(double glon, double glat,
                                  &temp_hour_angle) ;
 
     // Convert the apparent RA,Dec to galactic longitude,latitude
-    CIRS2Galactic(temp_ra, temp_dec, &temp_glon, &temp_glat, date) ;
+    CIRS2Galactic(temp_ra, temp_dec, observed_glon, observed_glat, date) ;
     
     return err_code ;
 }

--- a/src/CECoordinates.cpp
+++ b/src/CECoordinates.cpp
@@ -260,8 +260,14 @@ void CECoordinates::ICRS2CIRS(double input_ra, double input_dec,
     double eo ; // Equation of the origins
     
     // Use the sofa library to convert these coordinates
-    iauAtci13(input_ra, input_dec, 0, 0, 0, 0, date.JD(), 0.0, return_ra, return_dec, &eo) ;
-    *return_ra -= eo ;
+    try {
+        iauAtci13(input_ra, input_dec, 0, 0, 0, 0, date.JD(), 0.0, return_ra, return_dec, &eo) ;
+        *return_ra -= eo ;
+    } catch (std::exception &e) {
+        throw CEException::sofa_exception("CECoordinates::ICRS2CIRS",
+                                          "iauAtci13", 
+                                          "Exception thrown");
+    }
     
     // Convert the returned coordinates to the correct angle type
     if (angle_type == CEAngleType::DEGREES) {

--- a/src/CEException.cpp
+++ b/src/CEException.cpp
@@ -1,0 +1,101 @@
+/***************************************************************************
+ *  CEException.cpp: CppEphem                                                   *
+ * ----------------------------------------------------------------------- *
+ *  Copyright © 2019 JCardenzana                                           *
+ * ----------------------------------------------------------------------- *
+ *                                                                         *
+ *  This program is free software: you can redistribute it and/or modify   *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation, either version 3 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  This program is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *  You should have received a copy of the GNU General Public License      *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                         *
+ ***************************************************************************/
+
+/** \class CEException
+ CEException class handles Generic exceptions that may be thrown in the CppEphem
+ CppEphem code.
+ */
+
+#include "CEException.h"
+
+
+/**********************************************************************//**
+ * Generates and returns the error message
+ *  @return Formatted error message
+ *************************************************************************/
+CEExceptionHandler::CEExceptionHandler(const std::string& origin,
+                                       const std::string& message,
+                                       const std::string& type) :
+    CEExceptionHandler()
+{
+    origin_  = origin;
+    message_ = message;
+    type_    = type;
+}
+
+
+/**********************************************************************//**
+ * Generates and returns the error message
+ *  @return Formatted error message
+ *************************************************************************/
+const char* CEExceptionHandler::what() const noexcept
+{
+    // Define the header of the error message
+    std::string msg = "[ERROR] " + type_ + ": " + origin_ + "\n" + message_ + "\n";
+
+    return msg.c_str();
+}
+
+
+/**********************************************************************//**
+ * Generate an exception of type "invalid_value"
+ *  @param[in] origin       Method that threw the error
+ *  @param[in] message      Diagnostic message
+ *************************************************************************/
+CEException::invalid_value::invalid_value(const std::string& origin,
+                                          const std::string& message) :
+    CEExceptionHandler(origin, message, "Invalid Value")
+{}
+
+
+/**********************************************************************//**
+ * Generate an exception of type "sofa_exception"
+ *  @param[in] origin       Method that threw the error
+ *  @param[in] message      Diagnostic message
+ *************************************************************************/
+CEException::sofa_exception::sofa_exception(const std::string& origin,
+                                            const std::string& sofa_method,
+                                            const std::string& message) :
+    CEExceptionHandler(origin, message, "SOFA exception")
+{
+    // Overwrite the message
+    message_ = "SOFA method: " + sofa_method + "; " + message;
+}
+
+
+/**********************************************************************//**
+ * Generate an exception of type "sofa_error"
+ *  @param[in] origin       Method that threw the error
+ *  @param[in] message      Diagnostic message
+ * 
+ * This error should be used when a known error code is produced by a SOFA
+ * method.
+ *************************************************************************/
+CEException::sofa_error::sofa_error(const std::string& origin,
+                                    const std::string& sofa_method,
+                                    const int&         errcode,
+                                    const std::string& message) :
+    CEExceptionHandler(origin, message, "SOFA error")
+{
+    // Overwrite the message
+    message_ = "SOFA method: " + sofa_method + ", ErrCode: "+ std::to_string(errcode) +
+               "\n" + message;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ set (cppephem_SOURCES
     CEBody.cpp
     CECoordinates.cpp
     CEDate.cpp
+    CEException.cpp
     CEObservation.cpp
     CEObserver.cpp
     CEPlanet.cpp
@@ -26,6 +27,7 @@ set (cppephem_HEADERS
     ../include/CEBody.h
     ../include/CECoordinates.h
     ../include/CEDate.h
+    ../include/CEException.h
     ../include/CEObservation.h
     ../include/CEObserver.h
     ../include/CEPlanet.h

--- a/src/icrs2obs.cpp
+++ b/src/icrs2obs.cpp
@@ -58,23 +58,26 @@ CLOptions DefineOpts()
 
 /**********************************************************************//**
  *************************************************************************/
-void PrintResults(CECoordinates& input,
-                  CECoordinates& output,
-                  CEObserver&    observer,
-                  double jd)
+void PrintResults(CECoordinates& input_icrs,
+                  CECoordinates& observed_altaz,
+                  CECoordinates& observed_icrs,
+                  CEObserver&    observer)
 {
     std::printf("\n") ;
     std::printf("******************************************\n") ;
     std::printf("* Results of ICRS -> Observed conversion *\n") ;
     std::printf("******************************************\n") ;
     std::printf("Observed Coordinates (output)\n") ;
-    std::printf("    Azimuth        : %f degrees\n", output.XCoordinate_Deg()) ;
-    std::printf("    Zenith         : %+f degrees\n", output.YCoordinate_Deg()) ;
-    std::printf("    Altitude       : %+f degrees\n", 90.0-output.YCoordinate_Deg()) ;
+    std::printf("    Azimuth        : %f deg\n", observed_altaz.XCoordinate_Deg()) ;
+    std::printf("    Zenith         : %+f deg\n", observed_altaz.YCoordinate_Deg()) ;
+    std::printf("    Altitude       : %+f deg\n", 90.0-observed_altaz.YCoordinate_Deg()) ;
     std::printf("ICRS Coordinates (input)\n") ;
-    std::printf("    Right Ascension: %f degrees\n", input.XCoordinate_Deg()) ;
-    std::printf("    Declination    : %+f degrees\n", input.YCoordinate_Deg()) ;
-    std::printf("    Julian Date    : %f\n", jd) ;
+    std::printf("    Right Ascension: %f deg\n", input_icrs.XCoordinate_Deg()) ;
+    std::printf("    Declination    : %+f deg\n", input_icrs.YCoordinate_Deg()) ;
+    std::printf("    Julian Date    : %f\n", observer.Date()->JD()) ;
+    //std::printf("Apparent ICRS Coordinates\n");
+    //std::printf("    Right Ascension: %f deg\n", observed_icrs.XCoordinate_Deg());
+    //std::printf("    Declination    : %f deg\n", observed_icrs.XCoordinate_Deg());
     std::printf("Observer Info\n") ;
     std::printf("    Longitude      : %f deg\n", observer.Longitude_Deg()) ;
     std::printf("    Latitude       : %+f deg\n", observer.Latitude_Deg()) ;
@@ -102,27 +105,13 @@ int main(int argc, char** argv)
     CEObserver observer(opts.AsDouble("longitude"),
                         opts.AsDouble("latitude"),
                         opts.AsDouble("elevation"),
-                        CEAngleType::DEGREES, &date);
+                        CEAngleType::DEGREES, 
+                        &date);
     observer.SetPressure(opts.AsDouble("pressure"));
     observer.SetTemperature_C(opts.AsDouble("temperature"));
     observer.SetRelativeHumidity(opts.AsDouble("humidity"));
 
     // Convert the coordinates
-    /*
-    CECoordinates output = input.ConvertToObserved(opts.AsDouble("juliandate"),
-                                                   opts.AsDouble("longitude"),
-                                                   opts.AsDouble("latitude"),
-                                                   opts.AsDouble("elevation"),
-                                                   opts.AsDouble("pressure"),
-                                                   opts.AsDouble("temperature"),
-                                                   opts.AsDouble("humidity"),
-                                                   opts.AsDouble("dut1"),
-                                                   opts.AsDouble("xpolar"),
-                                                   opts.AsDouble("ypolar"),
-                                                   opts.AsDouble("wavelength"));
-    
-
-    */
     CECoordinates output;
     try {
         output = input.GetObservedCoords(date, observer,
@@ -135,7 +124,7 @@ int main(int argc, char** argv)
     }
     
     // Print the results
-    PrintResults(input, output, observer, opts.AsDouble("juliandate")) ;
+    PrintResults(input, output, output, observer) ;
     
     return 0 ;
 }


### PR DESCRIPTION
Fixes #8. Changed the internal workings of CECoordinates to ensure that pointers to `double`s are valid and not `nullptr` before passing them to the associated SOFA routines.

Also:
* Applied a fix to ensure 'observed' galactic coordinates are computed correctly by `CECoordinates::GalacticToObserved()`
* Add new class `CEException` to handle exceptions specific to CppEphem