### PR TITLE
Travis buldtest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ script:
 
 after_success:
  - llvm-cov gcov ./test/CMakeFiles/test_cppephem.dir/src/test_cppephem.cpp.o
+ - build-wrapper-linux-x86-64 --out-dir bw_output make clean all
  - sonar-scanner -Dproject.settings=sonar-project.properties
 
 # TODO: also need to test pure autotools build

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,6 @@ script:
 
 after_success:
  - llvm-cov gcov ./test/CMakeFiles/test_cppephem.dir/src/test_cppephem.cpp.o
- - sonar-scanner
+ - sonar-scanner -Dproject.settings=sonar-project.properties
 
 # TODO: also need to test pure autotools build

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,18 +3,20 @@ sonar.projectKey=cpp-ephem
 # this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
 sonar.projectName=CppEphem
 sonar.projectVersion=1.0
- 
+
+# Some repository specifics
+sonar.links.homepage=http://jvinniec.github.io/CppEphem/documentation/html/index.html
+sonar.links.ci=https://travis-ci.org/Jvinniec/CppEphem
+sonar.links.scm=https://github.com/Jvinniec/CppEphem
+sonar.links.issue=https://github.com/Jvinniec/CppEphem/issues
+
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # This property is optional if sonar.modules is set. 
 sonar.sources=src,include
 sonar.cxx.includeDirectories=include
-sonar.cxx.suffixes.sources=.cxx,.cpp,.cc,.c,.h
+sonar.cxx.suffixes.sources=.cxx,.cpp,.cc,.c,.h,.hpp
 sonar.cfamily.gcov.reportsPath=./
 
 # Encoding of the source code. Default is default system encoding
-sonar.sourceEncoding=UTF-8
-#sonar.language=cpp
-#sonar.cfamily.build-wrapper-output=build
-#sonar.cfamily.build-wrapper-output.bypass=true
 sonar.cfamily.build-wrapper-output=bw_output
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,4 +15,6 @@ sonar.cfamily.gcov.reportsPath=./
 sonar.sourceEncoding=UTF-8
 #sonar.language=cpp
 #sonar.cfamily.build-wrapper-output=build
-sonar.cfamily.build-wrapper-output.bypass=true
+#sonar.cfamily.build-wrapper-output.bypass=true
+sonar.cfamily.build-wrapper-output=bw_output
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Fixed the portions of the continuous build that were preventing `sonar-scanner` from running after travis-ci build tests.

Added some additional information for the sonarcloud site to link information back to the github repository.