### PR TITLE
CEPlanet observed coordinates fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v1.2.0 : HEAD
+- Update CEPlanet's conversion to observed coordinates
 - Update SOFA files to 20180130 [#5]
 - Add executables for cirs2icrs and gal2icrs [#14]
 - Standardize all executable parameters [#10]

--- a/cppephem/include/CEBody.h
+++ b/cppephem/include/CEBody.h
@@ -61,7 +61,9 @@ public:
      * Public methods
      ***********************************/
 
-    CECoordinates GetCoordinates(const CEDate& date=CEDate::CurrentJD()) const;
+    virtual CECoordinates GetCoordinates(const CEDate& date=CEDate::CurrentJD()) const;
+    virtual CECoordinates ObservedCoords(const CEDate&     date,
+                                         const CEObserver& observer) const;
     std::string   Name(void) const;
     void          SetName(const std::string& new_name);
     
@@ -105,7 +107,13 @@ void CEBody::SetName(const std::string& new_name)
 }
 
 /**********************************************************************//**
- * Return the coordinates associated with this object as a 'CECoordinates' object 
+ * Return the ICRS coordinates associated with this object
+ * 
+ * @param[in] date          Date for the coordinates
+ * @return Coordinates of this object in the ICRS frame 
+ * 
+ * Note that the date information is useful for those objects that may
+ * be either planets or stars with proper motion.
  *************************************************************************/
 inline
 CECoordinates CEBody::GetCoordinates(const CEDate& date) const

--- a/cppephem/include/CEObservation.h
+++ b/cppephem/include/CEObservation.h
@@ -85,9 +85,8 @@ private:
     // Cached the observed parameters to make subsequent calls faster,
     // i.e. since they all get computed at the same time there's no need
     // to recompute them unless something changes.
-    double cached_date_;         //<! Cached date, observed params recomputed if this has changed
-    double cached_azimuth_;      //<! Cached azimuth (radians)
-    double cached_zenith_;       //<! Cached zenith (radians)
+    double        cached_date_;   //<! Cached date, observed params recomputed if this has changed
+    CECoordinates cached_coords_; //<! Cached observed coordinates
     
     // Cache the apparent coordinates
     double cached_hour_angle_;   //<! Cached hour angle (radians)
@@ -168,7 +167,7 @@ inline
 double CEObservation::GetAzimuth_Rad()
 {
     UpdateCoordinates();
-    return cached_azimuth_;
+    return cached_coords_.XCoordinate_Rad();
 }
 
 
@@ -189,7 +188,7 @@ inline
 double CEObservation::GetZenith_Rad()
 {
     UpdateCoordinates();
-    return cached_zenith_;
+    return cached_coords_.YCoordinate_Rad();
 }
 
 
@@ -210,7 +209,7 @@ inline
 double CEObservation::GetAltitude_Rad()
 {
     UpdateCoordinates() ;
-    return (DPI/2.0) - cached_zenith_ ;
+    return (DPI/2.0) - GetZenith_Rad() ;
 }
 
 

--- a/cppephem/include/CEObserver.h
+++ b/cppephem/include/CEObserver.h
@@ -251,7 +251,7 @@ void CEObserver::SetUTCOffset(const double& utc_offset)
 
 
 /**********************************************************************//**
- * @return UTCOffset value of this observer
+ * @return UTCOffset value of this observer (hours)
  *************************************************************************/
 inline
 double CEObserver::UTCOffset() const

--- a/cppephem/include/CEObserver.h
+++ b/cppephem/include/CEObserver.h
@@ -76,7 +76,8 @@ public:
     void SetWavelength_um(const double& new_wavelength_um);
         
     /****************************************************
-     * Methods for interacting with the sofa functions
+     * Methods for extracting observed coordinates for
+     * a given object or coordinate
      ****************************************************/
     
     CECoordinates ObservedPosition(const CEBody& object,
@@ -84,6 +85,17 @@ public:
     CECoordinates ObservedPosition(const CECoordinates& coords,
                                    const CEDate&        date) ;
     
+    /****************************************************
+     * Methods for getting observer position and velocity
+     * vectors relative to CIRS and ICRS coordinates
+     ****************************************************/
+    std::vector<double> PositionGeo(void) const;
+    std::vector<double> PositionCIRS(const CEDate& date) const;
+    std::vector<double> PositionICRS(const CEDate& date) const;
+    std::vector<double> VelocityCIRS(const CEDate& date) const;
+    std::vector<double> VelocityICRS(const CEDate& date) const;
+
+    // Print information about the observer
     std::string print(void) const;
 
 private:
@@ -91,6 +103,9 @@ private:
     void copy_members(const CEObserver& other);
     void init_members(void);
     void free_members(void);
+
+    // Update teh Position and velocity vectors
+    void UpdatePosVel(const CEDate& date) const;
 
     // Variables which define the observers location on Earth
     double longitude_;              ///< Geographic longitude (radians)
@@ -103,6 +118,13 @@ private:
     double relative_humidity_;      ///< Relative humidity (in range 0-1)
     double wavelength_um_;          ///< Observing wavelength (micrometers)
     
+    // Cached position/velocity vectors
+    mutable double              cache_date_; ///< Date used to copute pos/vel vectors
+    mutable std::vector<double> pos_cirs_;   ///< XYZ position (AU) relative to Earth center
+    mutable std::vector<double> pos_icrs_;   ///< XYZ position (AU) relative to solar system barycenter
+    mutable std::vector<double> vel_cirs_;   ///< XYZ velocity (AU) relative to Earth center
+    mutable std::vector<double> vel_icrs_;   ///< XYZ veloicty (AU) relative to solar system barycenter
+
     // Variables defining the time of the observer
     double  utc_offset_;            ///< UTC offset in hours (set by default to system offset)
 };

--- a/cppephem/include/CEPlanet.h
+++ b/cppephem/include/CEPlanet.h
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include "CEBody.h"
+#include "CEObserver.h"
 
 /////////////////////////////////////////////
 /// Date enum
@@ -56,6 +57,9 @@ public:
     virtual double XCoordinate_Deg(double new_date=-1.0e30) const;
     virtual double YCoordinate_Rad(double new_date=-1.0e30) const;
     virtual double YCoordinate_Deg(double new_date=-1.0e30) const;
+    virtual double EarthDist_AU(const CEDate& date);
+    CECoordinates  ObservedCoords(const CEDate&     date,
+                                  const CEObserver& observer) const;
     virtual void   UpdateCoordinates(double new_date=-1.0e30) const;
     virtual void   Update_JPL(double new_date=-1.0e30) const;
     virtual void   Update_SOFA(double new_date=-1.0e30) const;
@@ -67,6 +71,7 @@ public:
     double GetYICRS();
     double GetZICRS();
     std::vector<double> PositionICRS(void) const;
+    std::vector<double> PositionICRS_Obs(const CEDate& date) const;
     double GetVxICRS();
     double GetVyICRS();
     double GetVzICRS();

--- a/cppephem/include/CEPlanet.h
+++ b/cppephem/include/CEPlanet.h
@@ -58,11 +58,13 @@ public:
     virtual double YCoordinate_Rad(double new_date=-1.0e30) const;
     virtual double YCoordinate_Deg(double new_date=-1.0e30) const;
     virtual double EarthDist_AU(const CEDate& date);
-    CECoordinates  ObservedCoords(const CEDate&     date,
-                                  const CEObserver& observer) const;
     virtual void   UpdateCoordinates(double new_date=-1.0e30) const;
     virtual void   Update_JPL(double new_date=-1.0e30) const;
     virtual void   Update_SOFA(double new_date=-1.0e30) const;
+    
+    // Override CEBody methods
+    virtual CECoordinates  ObservedCoords(const CEDate&     date,
+                                          const CEObserver& observer) const;
     
     /****************************
      * Methods for getting the current x,y,z coordinates and velocities relative to the ICRS point

--- a/cppephem/src/CEBody.cpp
+++ b/cppephem/src/CEBody.cpp
@@ -122,6 +122,18 @@ CEBody& CEBody::operator=(const CEBody& other)
  *--------------------------------------------------*/
 
 
+/**********************************************************************//**
+ * Computes the observed coordinates for this object based 
+ *************************************************************************/
+CECoordinates CEBody::ObservedCoords(const CEDate&     date,
+                                     const CEObserver& observer) const
+{
+    std::cout << "CALLED FROM CEBODY" << std::endl;
+    CECoordinates coords_icrs = GetCoordinates(date);
+    return coords_icrs.ConvertTo(CECoordinateType::OBSERVED, observer, date);
+}                                         
+
+
 /*--------------------------------------------------*
  *                  Private methods
  *--------------------------------------------------*/

--- a/cppephem/src/CEBody.cpp
+++ b/cppephem/src/CEBody.cpp
@@ -128,7 +128,6 @@ CEBody& CEBody::operator=(const CEBody& other)
 CECoordinates CEBody::ObservedCoords(const CEDate&     date,
                                      const CEObserver& observer) const
 {
-    std::cout << "CALLED FROM CEBODY" << std::endl;
     CECoordinates coords_icrs = GetCoordinates(date);
     return coords_icrs.ConvertTo(CECoordinateType::OBSERVED, observer, date);
 }                                         

--- a/cppephem/src/CECoordinates.cpp
+++ b/cppephem/src/CECoordinates.cpp
@@ -732,8 +732,9 @@ int CECoordinates::CIRS2Observed(double ra, double dec,
     // Call the necessary sofa method
     int err_code = 0;
     try {
+        CEDate date(julian_date, CEDateType::JD);
         err_code = iauAtio13(ra, dec,
-                             julian_date, 0.0,
+                             CEDate::GetMJD2JDFactor(), date.MJD(),
                              dut1,
                              longitude,
                              latitude,
@@ -790,8 +791,9 @@ int CECoordinates::Observed2CIRS(double az, double zen,
                                  double xp, double yp,
                                  double wavelength_um)
 {
+    CEDate date(julian_date, CEDateType::JD);
     int err_code = iauAtoi13("A", az, zen,
-                             julian_date, 0.0,
+                             CEDate::GetMJD2JDFactor(), date.MJD(),
                              dut1,
                              longitude, latitude,
                              elevation_m,
@@ -853,7 +855,7 @@ int CECoordinates::ICRS2Observed(double ra, double dec,
     if (observed_dec == nullptr) observed_dec = &temp_dec;
     if (hour_angle   == nullptr) hour_angle   = &temp_hour_angle;
     
-    // First convert the ICRS coordinats to CIRS coordinates
+    // First convert the ICRS coordinates to CIRS coordinates
     CEDate date(julian_date, CEDateType::JD) ;
     ICRS2CIRS(ra, dec, &ra, &dec, date) ;
     
@@ -1598,7 +1600,7 @@ CECoordinates CECoordinates::ConvertToObserved(double jd,
             // Cant convert from observed to observed without additional
             // observer information
             msg += "Unable to convert to OBSERVED from OBSERVED";
-    } else {
+        } else {
             // The coordinate type of this object is unknown... this shouldn't
             // happen if the developers have done their job.
             msg += "Unrecognized coordinate type";

--- a/cppephem/src/CECoordinates.cpp
+++ b/cppephem/src/CECoordinates.cpp
@@ -1591,11 +1591,20 @@ CECoordinates CECoordinates::ConvertToObserved(double jd,
                       dut1, xp, yp,
                       wavelength_um,
                       &apparent_x, &apparent_y, &apparent_hourangle) ;
-    } else if (coord_type_ == CECoordinateType::OBSERVED) {
-        xcoord_new = XCoordinate_Rad() ;
-        ycoord_new = YCoordinate_Rad() ;
     } else {
-        std::cerr << "[ERROR] Unknown coordinate type!\n" ;
+        // Throw an exception
+        std::string msg = "[ERROR] ";
+        if (coord_type_ == CECoordinateType::OBSERVED) {
+            // Cant convert from observed to observed without additional
+            // observer information
+            msg += "Unable to convert to OBSERVED from OBSERVED";
+    } else {
+            // The coordinate type of this object is unknown... this shouldn't
+            // happen if the developers have done their job.
+            msg += "Unrecognized coordinate type";
+        }
+        throw CEException::invalid_value("CECoordinates::ConvertToObserved(long form)",
+                                         msg);
     }
  
     return CECoordinates(xcoord_new, ycoord_new, CECoordinateType::OBSERVED,

--- a/cppephem/src/CECoordinates.cpp
+++ b/cppephem/src/CECoordinates.cpp
@@ -1115,6 +1115,9 @@ CECoordinates CECoordinates::GetObservedCoords(const double& julian_date,
                           elevation_m, pressure_hPa, temperature_celsius,
                           relative_humidity, dut1, xp, yp, wavelength,
                           &observed1, &observed2, &observed3) ;
+    } else if (coord_type_ == CECoordinateType::OBSERVED) {
+        azimuth = xcoord_;
+        zenith  = ycoord_; 
     } else {
         std::string msg = "Unrecognized coordinate type";
         throw CEException::invalid_value("CECoordinates::GetObservedCoords", msg);

--- a/cppephem/src/CECoordinates.cpp
+++ b/cppephem/src/CECoordinates.cpp
@@ -1175,16 +1175,36 @@ double CECoordinates::AngularSeparation(const CECoordinates& coords,
  * @param[in] coords2              Second set of coordinates
  * @param[in] return_angle_type    Specify whether to return angle as DEGREES or RADIANS
  * @return Angular separation between two coordiantes
+ * 
+ * Note that the x-coordinates are expected in the range [0, 2pi] and the
+ * y-coordinates are expected in the range [-pi, pi]. Because of this, you
+ * need to pass:
+ *  - ICRS: RA, Dec
+ *  - CIRS: RA, Dec
+ *  - GALACTIC: G.Lon, G.Lat
+ *  - OBSERVED: Az, Alt (by default the y-coordinate is zenith)
  *************************************************************************/
 double CECoordinates::AngularSeparation(const CECoordinates& coords1, 
                                         const CECoordinates& coords2,
                                         const CEAngleType& return_angle_type)
 {
+    // Make sure the coordinates are in the same frame
+    if (coords1.GetCoordSystem() != coords2.GetCoordSystem()) {
+        throw CEException::invalid_value("CECoordinates::AngularSeparation(CECoords&, CECoords&)",
+                                         "Supplied coordinates are in different frames");
+    }
+
+    // Get the appropriate Y-Coordinates
+    double y1 = coords1.YCoordinate_Rad();
+    double y2 = coords2.YCoordinate_Rad();
+    if (coords1.GetCoordSystem() == CECoordinateType::OBSERVED) {
+        y1 = M_PI_2 - y1;
+        y2 = M_PI_2 - y2;
+    }
+
     // Convert the second coordinates to be the same type as the first set of coordinates
-    double angsep = AngularSeparation(coords1.XCoordinate_Rad(),
-                                      coords1.YCoordinate_Rad(),
-                                      coords2.XCoordinate_Rad(),
-                                      coords2.YCoordinate_Rad(),
+    double angsep = AngularSeparation(coords1.XCoordinate_Rad(), y1,
+                                      coords2.XCoordinate_Rad(), y2,
                                       CEAngleType::RADIANS) ;
     // Convert radians to degrees if a return type of degrees is requested
     if (return_angle_type == CEAngleType::DEGREES) {
@@ -1207,6 +1227,14 @@ double CECoordinates::AngularSeparation(const CECoordinates& coords1,
  * @param[in] return_angle_type    Specify whether input angles are DEGREES or RADIANS.
  *                                 (output angle will be in the same format)
  * @return Angular separation between two coordinates
+ * 
+ * Note that the x-coordinates are expected in the range [0, 2pi] and the
+ * y-coordinates are expected in the range [-pi, pi]. Because of this, you
+ * need to pass:
+ *  - ICRS: RA, Dec
+ *  - CIRS: RA, Dec
+ *  - GALACTIC: G.Lon, G.Lat
+ *  - OBSERVED: Az, Alt (by default the y-coordinate is zenith)
  *************************************************************************/
 double CECoordinates::AngularSeparation(double xcoord_first, 
                                         double ycoord_first,

--- a/cppephem/src/CECoordinates.cpp
+++ b/cppephem/src/CECoordinates.cpp
@@ -684,13 +684,13 @@ int CECoordinates::Observed2Galactic(double az, double zen,
  * (uses the SOFA 'iauAtio13' function)
  * Note: All angles are expected to be in radians.
  * 
- * @param[in]  ra                   CIRS right ascension
- * @param[in]  dec                  CIRS declination
- * @param[out] az                   Observed azimuth angle (returned)
- * @param[out] zen                  Observed zenith angle (returned)
+ * @param[in]  ra                   CIRS right ascension (radians)
+ * @param[in]  dec                  CIRS declination (radians)
+ * @param[out] az                   Observed azimuth angle (radians, returned)
+ * @param[out] zen                  Observed zenith angle (radians, returned)
  * @param[in]  julian_date          Julian date for conversion
- * @param[in]  latitude             Observer geographic latitude
- * @param[in]  longitude            Observer geographic longitude
+ * @param[in]  longitude            Observer geographic longitude (radians)
+ * @param[in]  latitude             Observer geographic latitude (radians)
  * @param[in]  elevation_m          Observer elevation (meters)
  * @param[in]  pressure_hPa         Atmospheric pressure (HPa)
  * @param[in]  temperature_celsius  Temperature (degrees Celsius)
@@ -766,8 +766,8 @@ int CECoordinates::CIRS2Observed(double ra, double dec,
  * @param[out] ra                   CIRS right ascension (returned)
  * @param[out] dec                  CIRS declination (returned)
  * @param[in]  julian_date          Julian date for conversion
- * @param[in]  latitude             Observer geographic latitude
  * @param[in]  longitude            Observer geographic longitude
+ * @param[in]  latitude             Observer geographic latitude
  * @param[in]  elevation_m          Observer elevation (meters)
  * @param[in]  pressure_hPa         Atmospheric pressure (HPa)
  * @param[in]  temperature_celsius  Temperature (degrees Celsius)
@@ -808,13 +808,13 @@ int CECoordinates::Observed2CIRS(double az, double zen,
  * Raw method for converting CIRS -> Observed (observer specific) coordinates.
  * Note: All angles are expected to be in radians.
  * 
- * @param[in]  ra                   CIRS right ascension
- * @param[in]  dec                  CIRS declination
- * @param[out] az                   Observed azimuth angle (returned)
- * @param[out] zen                  Observed zenith angle (returned)
+ * @param[in]  ra                   CIRS right ascension (radians)
+ * @param[in]  dec                  CIRS declination (radians)
+ * @param[out] az                   Observed azimuth angle (radians, returned)
+ * @param[out] zen                  Observed zenith angle (radians, returned)
  * @param[in]  julian_date          Julian date for conversion
- * @param[in]  latitude             Observer geographic latitude
- * @param[in]  longitude            Observer geographic longitude
+ * @param[in]  longitude            Observer geographic longitude (radians)
+ * @param[in]  latitude             Observer geographic latitude (radians)
  * @param[in]  elevation_m          Observer elevation (meters)
  * @param[in]  pressure_hPa         Atmospheric pressure (HPa)
  * @param[in]  temperature_celsius  Temperature (degrees Celsius)
@@ -884,13 +884,13 @@ int CECoordinates::ICRS2Observed(double ra, double dec,
  * Raw method for converting Observed (observer specific) -> ICRS coordinates
  * Note: All angles are expected to be in radians.
  * 
- * @param[in]  az                   Observed azimuth angle
- * @param[in]  zen                  Observed zenith angle
- * @param[out] ra                   ICRS right ascension (returned)
- * @param[out] dec                  ICRS declination (returned)
+ * @param[in]  az                   Observed azimuth angle (radians)
+ * @param[in]  zen                  Observed zenith angle (radians)
+ * @param[out] ra                   ICRS right ascension (radians, returned)
+ * @param[out] dec                  ICRS declination (radians, returned)
  * @param[in]  julian_date          Julian date for conversion
- * @param[in]  latitude             Observer geographic latitude
- * @param[in]  longitude            Observer geographic longitude
+ * @param[in]  longitude            Observer geographic longitude (radians)
+ * @param[in]  latitude             Observer geographic latitude (radians)
  * @param[in]  elevation_m          Observer elevation (meters)
  * @param[in]  pressure_hPa         Atmospheric pressure (HPa)
  * @param[in]  temperature_celsius  Temperature (degrees Celsius)
@@ -935,13 +935,13 @@ int CECoordinates::Observed2ICRS(double az, double zen,
  * Raw method for converting Galactic -> Observed (observer specific) coordinates.
  * Note: All angles are expected to be in radians.
  * 
- * @param[in]  glon                 Galactic longitude
- * @param[in]  glat                 Galactic latitude
- * @param[out] az                   Observed azimuth angle (returned)
- * @param[out] zen                  Observed zenith angle (returned)
+ * @param[in]  glon                 Galactic longitude (radians)
+ * @param[in]  glat                 Galactic latitude (radians)
+ * @param[out] az                   Observed azimuth angle (radians, returned)
+ * @param[out] zen                  Observed zenith angle (radians, returned)
  * @param[in]  julian_date          Julian date for conversion
- * @param[in]  latitude             Observer geographic latitude
- * @param[in]  longitude            Observer geographic longitude
+ * @param[in]  longitude            Observer geographic longitude (radians)
+ * @param[in]  latitude             Observer geographic latitude (radians)
  * @param[in]  elevation_m          Observer elevation (meters)
  * @param[in]  pressure_hPa         Atmospheric pressure (HPa)
  * @param[in]  temperature_celsius  Temperature (degrees Celsius)
@@ -1016,11 +1016,11 @@ int CECoordinates::Galactic2Observed(double glon, double glat,
  * 
  * @param[in]  az                   Observed azimuth angle (radians)
  * @param[in]  zen                  Observed zenith angle (radians)
- * @param[out] glon                 Galactic longitude (returned)
- * @param[out] glat                 Galactic latitude (returned)
+ * @param[out] glon                 Galactic longitude (radians, returned)
+ * @param[out] glat                 Galactic latitude (radians, returned)
  * @param[in]  julian_date          Julian date for conversion
- * @param[in]  latitude             Observer geographic latitude
- * @param[in]  longitude            Observer geographic longitude
+ * @param[in]  longitude            Observer geographic longitude (radians)
+ * @param[in]  latitude             Observer geographic latitude (radians)
  * @param[in]  elevation_m          Observer elevation (meters)
  * @param[in]  pressure_hPa         Atmospheric pressure (HPa)
  * @param[in]  temperature_celsius  Temperature (degrees Celsius)
@@ -1180,12 +1180,8 @@ double CECoordinates::AngularSeparation(const CECoordinates& coords,
  * @return Angular separation between two coordiantes
  * 
  * Note that the x-coordinates are expected in the range [0, 2pi] and the
- * y-coordinates are expected in the range [-pi, pi]. Because of this, you
- * need to pass:
- *  - ICRS: RA, Dec
- *  - CIRS: RA, Dec
- *  - GALACTIC: G.Lon, G.Lat
- *  - OBSERVED: Az, Alt (by default the y-coordinate is zenith)
+ * y-coordinates are expected in the range [-pi, pi]. Because of this, OBSERVED
+ * coordinates first convert the zenith angle to altitude
  *************************************************************************/
 double CECoordinates::AngularSeparation(const CECoordinates& coords1, 
                                         const CECoordinates& coords2,

--- a/cppephem/src/CEObservation.cpp
+++ b/cppephem/src/CEObservation.cpp
@@ -164,13 +164,9 @@ void CEObservation::GetApparentXYCoordinate_Deg(double *apparent_X, double *appa
 bool CEObservation::UpdateCoordinates()
 {
     if (NeedsUpdate()) {
-        // Get the coordinates
-        CECoordinates coords = observer_->ObservedPosition(*body_, *date_);
-        
-        // Update the cached parameters
-        cached_date_     = *date_ ;
-        cached_azimuth_  = coords.XCoordinate_Rad();
-        cached_zenith_   = coords.YCoordinate_Rad();
+        // Get the coordinates and date
+        cached_coords_ = body_->ObservedCoords(*date_, *observer_);
+        cached_date_   = *date_;
     }
     return true ;
 }
@@ -190,8 +186,7 @@ void CEObservation::copy_members(const CEObservation& other)
 
     // Copy the cached values
     cached_date_       = other.cached_date_;
-    cached_azimuth_    = other.cached_azimuth_;
-    cached_zenith_     = other.cached_zenith_;
+    cached_coords_     = other.cached_coords_;
     cached_hour_angle_ = other.cached_hour_angle_;
     cached_apparentxcoord_ = other.cached_apparentxcoord_;
     cached_apparentycoord_ = other.cached_apparentycoord_;
@@ -210,8 +205,7 @@ void CEObservation::init_members(void)
 
     // Copy the cached values
     cached_date_           = 0.0;
-    cached_azimuth_        = 0.0;
-    cached_zenith_         = 0.0;
+    cached_coords_         = CECoordinates();
 
     // Note that these are not filled at the moment
     cached_hour_angle_     = 0.0;

--- a/cppephem/src/CEObservation.cpp
+++ b/cppephem/src/CEObservation.cpp
@@ -171,7 +171,7 @@ bool CEObservation::UpdateCoordinates()
         cached_date_     = *date_ ;
         cached_azimuth_  = coords.XCoordinate_Rad();
         cached_zenith_   = coords.YCoordinate_Rad();
-    }    
+    }
     return true ;
 }
 

--- a/cppephem/src/CEObserver.cpp
+++ b/cppephem/src/CEObserver.cpp
@@ -265,7 +265,7 @@ void CEObserver::init_members(void)
     latitude_            = 0.0;
     elevation_m_         = 0.0;
     temperature_celsius_ = CppEphem::SeaLevelTemp_C();
-    pressure_hPa_        = CppEphem::EstimatePressure_hPa(temperature_celsius_);
+    pressure_hPa_        = CppEphem::EstimatePressure_hPa(elevation_m_);
     relative_humidity_   = 0.0;
     wavelength_um_       = 0.5;
     utc_offset_          = CETime::SystemUTCOffset_hrs();

--- a/cppephem/src/CEObserver.cpp
+++ b/cppephem/src/CEObserver.cpp
@@ -300,14 +300,11 @@ void CEObserver::UpdatePosVel(const CEDate& date) const
         CEDate::UTC2TT(date.MJD(), &tt1, &tt2);
 
         // Compute the Earth rotation angle at UT1
-        //iauBpn2xy(r, &x, &y);
         double theta = iauEra00(ut11, ut12);
-        //double s     = iauS06(tt1, tt2, x, y);
         double sp    = iauSp00(tt1, tt2);
 
         // Vectors for intermediate position/velocities
         double pvc[2][3];   // CIRS pos,vel
-        double pvg[2][3];   // GCRS pos,vel
 
         // Get the position and velocity values in CIRS
         iauPvtob(longitude_, 
@@ -318,11 +315,6 @@ void CEObserver::UpdatePosVel(const CEDate& date) const
                  sp,
                  theta,
                  pvc);
-
-        // Apply rotattion from CIRS -> GCRS
-        double r[3][3];
-        iauPnm06a(tt1, tt2, r);
-        iauTrxpv(r, pvc, pvg);
 
         // Earth centric distance/velocity in ICRS (AU and AU/day)
         double ebpv[2][3];
@@ -336,9 +328,9 @@ void CEObserver::UpdatePosVel(const CEDate& date) const
             pos_cirs_[i] = pvc[0][i] / CppEphem::m_per_au();
             vel_cirs_[i] = pvc[1][i] * mps_apd;
 
-            // ICRS (Earth barycenter + GCRS offset)
-            pos_icrs_[i] = ebpv[0][i] + (pvg[0][i] / CppEphem::m_per_au());
-            vel_icrs_[i] = ebpv[1][i] + (pvg[1][i] * mps_apd);
+            // ICRS (Earth barycenter + CIRS offset)
+            pos_icrs_[i] = ebpv[0][i] + pos_cirs_[i];
+            vel_icrs_[i] = ebpv[1][i] + vel_cirs_[i];
         }
     }
     return;

--- a/cppephem/src/CEObserver.cpp
+++ b/cppephem/src/CEObserver.cpp
@@ -243,6 +243,7 @@ void CEObserver::copy_members(const CEObserver& other)
     elevation_m_         = other.elevation_m_;
     pressure_hPa_        = other.pressure_hPa_;
     temperature_celsius_ = other.temperature_celsius_;
+    wavelength_um_       = other.wavelength_um_;
     relative_humidity_   = other.relative_humidity_;
     utc_offset_          = other.utc_offset_;
 
@@ -266,6 +267,7 @@ void CEObserver::init_members(void)
     temperature_celsius_ = CppEphem::SeaLevelTemp_C();
     pressure_hPa_        = CppEphem::EstimatePressure_hPa(temperature_celsius_);
     relative_humidity_   = 0.0;
+    wavelength_um_       = 0.5;
     utc_offset_          = CETime::SystemUTCOffset_hrs();
 
     // cached pos/vel parameters

--- a/cppephem/src/CEObserver.cpp
+++ b/cppephem/src/CEObserver.cpp
@@ -120,7 +120,7 @@ CEObserver& CEObserver::operator=(const CEObserver& other)
 CECoordinates CEObserver::ObservedPosition(const CEBody& object,
                                            const CEDate& date)
 {
-    CECoordinates coords = object.GetCoordinates(date);
+    CECoordinates coords = object.ObservedCoords(date, *this);
     return this->ObservedPosition(coords, date);
 }
 
@@ -135,8 +135,8 @@ CECoordinates CEObserver::ObservedPosition(const CECoordinates& coords,
                                            const CEDate&        date)
 {
     // Compute the observed coordinates for these coordinates
-    CECoordinates tmpcoords(coords);
-    CECoordinates observed_coords = tmpcoords.GetObservedCoords(date,*this);
+    //CECoordinates tmpcoords(coords);
+    CECoordinates observed_coords = coords.GetObservedCoords(date,*this);
     return observed_coords;
 }
 

--- a/cppephem/src/CEObserver.cpp
+++ b/cppephem/src/CEObserver.cpp
@@ -135,7 +135,6 @@ CECoordinates CEObserver::ObservedPosition(const CECoordinates& coords,
                                            const CEDate&        date)
 {
     // Compute the observed coordinates for these coordinates
-    //CECoordinates tmpcoords(coords);
     CECoordinates observed_coords = coords.GetObservedCoords(date,*this);
     return observed_coords;
 }

--- a/cppephem/src/CEPlanet.cpp
+++ b/cppephem/src/CEPlanet.cpp
@@ -666,7 +666,7 @@ CECoordinates CEPlanet::ObservedCoords(const CEDate&     date,
     }
     CECoordinates coord(ra, dec, coordsys, CEAngleType::RADIANS);
     
-    return coord.GetObservedCoords(date, observer);
+    return coord.ConvertTo(CECoordinateType::OBSERVED, observer, date);
 }
 
 

--- a/cppephem/src/planetephem.cpp
+++ b/cppephem/src/planetephem.cpp
@@ -178,12 +178,14 @@ void PrintEphemeris(CEObservation& obs,
     std::vector<double> localtime = CETime::TimeDbl2Vect(date->GetTime(observer->UTCOffset()));
     
     // Print some information about the observer
-    std::vector<double> long_hms = CECoordinates::GetDMS( observer->Longitude_Deg() );
-    std::vector<double> lat_hms  = CECoordinates::GetDMS( observer->Latitude_Deg() );
+    std::vector<double> long_hms = CECoordinates::GetDMS( observer->Longitude_Deg(),
+                                                          CEAngleType::DEGREES );
+    std::vector<double> lat_hms  = CECoordinates::GetDMS( observer->Latitude_Deg(),
+                                                          CEAngleType::DEGREES );
     std::printf("\n") ;
     std::printf("= OBSERVER ===================\n");
-    std::printf("  Longitude: %+4dd %02dm %4.1fs\n", int(long_hms[0]), int(long_hms[1]), long_hms[2]);
-    std::printf("  Latitude :  %+2dd %02dm %4.1fs\n", int(lat_hms[0]), int(lat_hms[1]), lat_hms[2]);
+    std::printf("  Longitude: %+4dd %02dm %4.1fs\n", int(long_hms[0]), int(long_hms[1]), long_hms[2]+long_hms[3]);
+    std::printf("  Latitude :  %+3dd %02dm %4.1fs\n", int(lat_hms[0]), int(lat_hms[1]), lat_hms[2]+lat_hms[3]);
     std::printf("  Elevation: %f m \n", observer->Elevation_m());
     std::printf("  Pressure : %f hPa\n", observer->Pressure_hPa());
     std::printf("  Temp     : %f Celsius\n", observer->Temperature_C());

--- a/cppephem/src/planetephem.cpp
+++ b/cppephem/src/planetephem.cpp
@@ -194,10 +194,10 @@ void PrintEphemeris(CEObservation& obs,
         
         std::printf(" %11.2f  %08.1f  %2.0fh %2.0fm %4.1fs  %+3.0fd %2.0fm %4.1fs  %8.3f  %+7.3f\n",
                     double(*date), date->GetTime(observer->UTCOffset()),
-                    ra[0], ra[1], ra[2],
-                    dec[0], dec[1], dec[2],
-                    obs.GetAzimuth_Deg(),
-                    90.0-obs.GetZenith_Deg());
+                    ra[0], ra[1], ra[2] + ra[3],
+                    dec[0], dec[1], dec[2] + dec[3],
+                    obs_coords.XCoordinate_Deg(),
+                    90.0-obs_coords.YCoordinate_Deg());
         
         // Update the date
         date->SetDate(*date + step_size/(60.0*24.0));

--- a/cppephem/test/astropy_scripts/test_ceobserver_setup.py
+++ b/cppephem/test/astropy_scripts/test_ceobserver_setup.py
@@ -13,5 +13,6 @@ test = SkyCoord(0.0*u.deg, 90.0*u.deg, frame='icrs')
 obs_coords = test.transform_to(aa)
 zenith = 90 - obs_coords.alt.deg
 
+print(f"Observer Info:\n   {earth_pos.x:10.5f}")
 print(f"Input: {test}")
 print(f"Output: (az,alt) = ({obs_coords.az}, {zenith} deg)")

--- a/cppephem/test/astropy_scripts/test_ceplanet_setup.py
+++ b/cppephem/test/astropy_scripts/test_ceplanet_setup.py
@@ -28,11 +28,13 @@ def print_planet_position(name, observer, time):
     aa   = AltAz(location=observer, obstime=time)
     obs  = planet.transform_to(aa)
     icrs = planet.transform_to('icrs')
+    cirs = planet.transform_to('cirs')
 
     # Compute the position/velocity of the object
     pos, vel = solar_system.get_body_barycentric_posvel(body = name, 
                                                         time = time)
     print(f"{name:8}: obs=({obs.az:20.16f},{obs.zen:20.16f}) | icrs=({icrs.ra:20.16f},{icrs.dec:20.16f})")
+    print(f"          cirs=({cirs.ra:20.16f},{cirs.dec:20.16f})")
     print(f"          pos={pos}, vel={vel}")
 
 

--- a/cppephem/test/test_CEObserver.cpp
+++ b/cppephem/test/test_CEObserver.cpp
@@ -82,8 +82,9 @@ bool test_CEObserver::test_constructor(void)
     test_double(test1.Longitude_Rad(), 0.0, __func__, __LINE__);
     test_double(test1.Latitude_Rad(),  0.0,  __func__, __LINE__);
     test_double(test1.Temperature_C(), CppEphem::SeaLevelTemp_C(), __func__, __LINE__);
-    test_double(test1.Pressure_hPa(),  CppEphem::EstimatePressure_hPa(test1.Temperature_C()),  __func__, __LINE__);
+    test_double(test1.Pressure_hPa(),  CppEphem::EstimatePressure_hPa(test1.Elevation_m()),  __func__, __LINE__);
     test_double(test1.RelativeHumidity(), 0.0, __func__, __LINE__);
+    test_double(test1.Wavelength_um(), 0.5, __func__, __LINE__);
 
     // Create a copy for testing
     CEObserver test2(base_obs_);
@@ -92,6 +93,7 @@ bool test_CEObserver::test_constructor(void)
     test_double(test2.Temperature_K(), base_obs_.Temperature_K(), __func__, __LINE__);
     test_double(test2.Pressure_hPa(),  base_obs_.Pressure_hPa(),  __func__, __LINE__);
     test_double(test2.RelativeHumidity(), base_obs_.RelativeHumidity(), __func__, __LINE__);
+    test_double(test2.Wavelength_um(), base_obs_.Wavelength_um(), __func__, __LINE__);
 
     // Copy assignment operator
     CEObserver test3 = base_obs_;
@@ -100,6 +102,7 @@ bool test_CEObserver::test_constructor(void)
     test_double(test3.Temperature_K(), base_obs_.Temperature_K(), __func__, __LINE__);
     test_double(test3.Pressure_hPa(),  base_obs_.Pressure_hPa(),  __func__, __LINE__);
     test_double(test3.RelativeHumidity(), base_obs_.RelativeHumidity(), __func__, __LINE__);
+    test_double(test3.Wavelength_um(), base_obs_.Wavelength_um(), __func__, __LINE__);
 
     return pass();
 }

--- a/cppephem/test/test_CEObserver.cpp
+++ b/cppephem/test/test_CEObserver.cpp
@@ -140,6 +140,12 @@ bool test_CEObserver::test_set_geoCoords()
     obs.SetUTCOffset(utc_offset);
     test_double(obs.UTCOffset(), utc_offset, __func__, __LINE__);
 
+    // Test that we get similar positions to Astropy
+    CEDate date(CppEphem::julian_date_J2000(), CEDateType::JD);
+    std::vector<double> earth_pos_m = {6378137.00000, 0.0, 0.0};
+    std::vector<double> test_pos_m  = base_obs_.PositionGeo();
+    test_vect(test_pos_m, earth_pos_m, __func__, __LINE__);
+
     return pass();
 }
 

--- a/cppephem/test/test_CEPlanet.cpp
+++ b/cppephem/test/test_CEPlanet.cpp
@@ -124,8 +124,9 @@ bool test_CEPlanet::test_mercury(void)
     // Run the actual test with values derived from AstroPy
     test_planet(mercury,
                 CECoordinates(251.1840266663606371, -25.3023875289787838, 
-                              CECoordinateType::ICRS, 
-                              CEAngleType::DEGREES),
+                              CECoordinateType::ICRS, CEAngleType::DEGREES),
+                CECoordinates(197.8036693771968260, 25.7350871794139664,
+                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
                 {-0.13721236, -0.4032437, -0.20141521},
                 {0.02137206, -0.00493223, -0.00485005});
 
@@ -148,8 +149,9 @@ bool test_CEPlanet::test_venus(void)
     // Run the actual test with values derived from AstroPy
     test_planet(venus,
                 CECoordinates(183.8496760951891247, 1.8722067172672485, 
-                              CECoordinateType::ICRS, 
-                              CEAngleType::DEGREES),
+                              CECoordinateType::ICRS, CEAngleType::DEGREES),
+                CECoordinates(242.8427330437376099, 43.8958267247570220,
+                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
                 {-0.72543765, -0.04893718, 0.02371176},
                 {0.00080326, -0.01849847, -0.00837267});
 
@@ -172,8 +174,9 @@ bool test_CEPlanet::test_earth(void)
     // Run the actual test with values derived from AstroPy
     test_planet(earth,
                 CECoordinates(101.7655134417398273, 23.0103434895188776, 
-                              CECoordinateType::ICRS, 
-                              CEAngleType::DEGREES),
+                              CECoordinateType::ICRS, CEAngleType::DEGREES),
+                CECoordinates(89.9999999991386233, 179.9999111107912881,
+                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
                 {-0.18428431, 0.88477935, 0.383819},
                 {-0.01720221, -0.00290513, -0.00125952});
     
@@ -196,8 +199,9 @@ bool test_CEPlanet::test_mars(void)
     // Run the actual test with values derived from AstroPy
     test_planet(mars,
                 CECoordinates(359.9442433037739306, -1.5700885004650793, 
-                              CECoordinateType::ICRS, 
-                              CEAngleType::DEGREES),
+                              CECoordinateType::ICRS, CEAngleType::DEGREES),
+                CECoordinates(106.9869245851015762, 51.3129710961485586,
+                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
                 {1.38356924, -0.0011989, -0.0378561},
                 {0.00067763, 0.01380768, 0.00631503});
 
@@ -239,8 +243,9 @@ bool test_CEPlanet::test_jupiter(void)
     // Run the actual test with values derived from AstroPy
     test_planet(jupiter,
                 CECoordinates(34.3822629405528843, 12.5158780867456674, 
-                              CECoordinateType::ICRS, 
-                              CEAngleType::DEGREES),
+                              CECoordinateType::ICRS, CEAngleType::DEGREES),
+                CECoordinates(81.1700048918871886, 103.2491992750974532, 
+                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
                 {3.99442023, 2.7334608, 1.07451899},
                 {-0.00455544, 0.00587705, 0.00263009});
     
@@ -263,8 +268,9 @@ bool test_CEPlanet::test_saturn(void)
     // Run the actual test with values derived from AstroPy
     test_planet(saturn,
                 CECoordinates(43.9734819060061355, 14.3451097907081060, 
-                              CECoordinateType::ICRS, 
-                              CEAngleType::DEGREES),
+                              CECoordinateType::ICRS, CEAngleType::DEGREES),
+                CECoordinates(75.7370064470109696, 117.5753277202141760, 
+                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
                 {6.39746262, 6.17262105, 2.2735304},
                 {-0.00429156, 0.00350834, 0.00163369});
     
@@ -287,8 +293,9 @@ bool test_CEPlanet::test_uranus(void)
     // Run the actual test with values derived from AstroPy
     test_planet(uranus,
                 CECoordinates(319.0662412483117691, -16.5756054581048744, 
-                              CECoordinateType::ICRS, 
-                              CEAngleType::DEGREES),
+                              CECoordinateType::ICRS, CEAngleType::DEGREES),
+                CECoordinates(116.9533213948411401, 40.2264403677069211, 
+                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
                 {14.42492523, -12.50957402, -5.6830779},
                 {0.00269067, 0.00244776, 0.00103396});
     
@@ -311,8 +318,9 @@ bool test_CEPlanet::test_neptune(void)
     // Run the actual test with values derived from AstroPy
     test_planet(neptune,
                 CECoordinates(306.1731137010386306, -19.0396553491478997, 
-                              CECoordinateType::ICRS, 
-                              CEAngleType::DEGREES),
+                              CECoordinateType::ICRS, CEAngleType::DEGREES),
+                CECoordinates(129.5362400208609870, 31.1291412849027509, 
+                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
                 {16.80489053, -22.98266171, -9.82533257},
                 {0.00258607, 0.00165554, 0.00061312});
 
@@ -331,24 +339,37 @@ bool test_CEPlanet::test_neptune(void)
  *************************************************************************/
 bool test_CEPlanet::test_planet(const CEPlanet&            test_planet,
                                 const CECoordinates&       true_icrs,
+                                const CECoordinates&       true_obs,
                                 const std::vector<double>& true_pos,
                                 const std::vector<double>& true_vel)
 {
     // Define a name so that we actually know which planet we're testing
     std::string func_name = std::string(__func__) + " (" + test_planet.Name() + ")";
 
+    // Test ICRS coordinates
     CECoordinates icrs_coords(test_planet.XCoordinate_Rad(),
                               test_planet.YCoordinate_Rad(),
                               CECoordinateType::ICRS,
-                              CEAngleType::RADIANS);
-    
+                              CEAngleType::RADIANS);    
     if (!test(icrs_coords == true_icrs, func_name, __LINE__)) {
         // Print information about the coordinates
-        std::printf("   %s   %s   %s", icrs_coords.print().c_str(), true_icrs.print().c_str(), icrs_coords.print().c_str());
+        std::printf("   %s   %s", icrs_coords.print().c_str(), true_icrs.print().c_str());
         std::printf("   X-diff: %f arcsec\n", (icrs_coords.XCoordinate_Deg()-true_icrs.XCoordinate_Deg())*3600.0);
         std::printf("   Y-diff: %f arcsec\n", (icrs_coords.YCoordinate_Deg()-true_icrs.YCoordinate_Deg())*3600.0);
     }
-    std::printf("      AngSep: %e arcsec\n", icrs_coords.AngularSeparation(true_icrs, CEAngleType::DEGREES)*3600.0);
+    std::printf("      AngSep ICRS: %e arcsec\n", icrs_coords.AngularSeparation(true_icrs, CEAngleType::DEGREES)*3600.0);
+
+    // Test observed coordinates
+    CECoordinates obs_coords = test_planet.ObservedCoords(base_date_, 
+                                                          base_observer_);
+
+    if (!test(obs_coords == true_obs, func_name, __LINE__)) {
+        // Print information about the coordinates
+        std::printf("   %s   %s", obs_coords.print().c_str(), true_obs.print().c_str());
+        std::printf("   X-diff: %f arcsec\n", (obs_coords.XCoordinate_Deg()-true_obs.XCoordinate_Deg())*3600.0);
+        std::printf("   Y-diff: %f arcsec\n", (obs_coords.YCoordinate_Deg()-true_obs.YCoordinate_Deg())*3600.0);
+    }
+    std::printf("      AngSep Obs : %e arcsec\n", obs_coords.AngularSeparation(true_obs, CEAngleType::DEGREES)*3600.0);
 
     // Update the tolerance
     double tol_old = DblTol();

--- a/cppephem/test/test_CEPlanet.h
+++ b/cppephem/test/test_CEPlanet.h
@@ -51,6 +51,7 @@ public:
     // Run the actual tests
     virtual bool test_planet(const CEPlanet&            test_planet,
                              const CECoordinates&       true_icrs,
+                             const CECoordinates&       true_obs,
                              const std::vector<double>& true_pos,
                              const std::vector<double>& true_vel);
 


### PR DESCRIPTION
This pull request fixes how classes inheriting from CEBody compute observed coordinates. Specifically, each method must now override the `CEBody::ObservedCoords(const CEDate&, const CEObserver&)` method. This method is overridden for CEPlanet now. 

This is done as different objects will have different methods for extracting their observed coordinates. For example, stars will need to account for proper motion and parallax distance whereas planets will need to account for the relative time delay between observer and the current planet position.