### PR TITLE
Autotools buildfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ add_subdirectory (test)
 #-------------------------------------------
 
 # Define installation directories
-install(DIRECTORY ${CMAKE_BINARY_DIR}include/
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/cppephem/include/
     USE_SOURCE_PERMISSIONS
 	DESTINATION ${CMAKE_INSTALL_PREFIX}/include
     FILES_MATCHING PATTERN "C*.h")

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,3 +2,10 @@
 
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = $(BUILDSUBDIRS)
+
+install-data-local:
+	$(MKDIR_P) $(cecorrfilepath)
+
+uninstall-local:
+	$(cleanup_corrfilepath)
+    

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,13 @@
+v1.2.0
+-------
+This represents the most significant change to the code base since its creation.
+The most significant change involves more accurate coordinates by including
+the automatic download of 'UT1-UTC', 'x,y-polar motion', and "TT-UT1" correction
+values. These values are also automatically applied to coordinate conversions
+and planet position computations.
+
+Another decision that has been made is the choice to deprecate the autotools
+based method for installing the code. This is being done due to the complexity
+of maintaining the build system and testing code. It's just too much effort for
+a small project with a one-man development team. In the next release (v1.3.0)
+the autotools system will be removed and CMake will be required.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Here is a list of purposes I wish this code to serve:
   - [ICRS](https://github.com/Jvinniec/CppEphem/wiki/Coordinate-Systems#icrs) (Solarsystem barycentric RA, Dec)
   - [Galactic](https://github.com/Jvinniec/CppEphem/wiki/Coordinate-Systems#galactic) (Long, Lat)
   - [Observed](https://github.com/Jvinniec/CppEphem/wiki/Coordinate-Systems#observed) (Azimuth, Zenith angle) (Note: Zenith angle = 90&deg; - Altitude)
-  - [Ecliptic](https://github.com/Jvinniec/CppEphem/wiki/Coordinate-Systems#ecliptic) (Long, Lat) Will allow for either heliocentric or Earth centric variants (Not yet implemented)
+  - ~~[Ecliptic](https://github.com/Jvinniec/CppEphem/wiki/Coordinate-Systems#ecliptic)~~ (Not yet implemented, Long, Lat) Will allow for either heliocentric or Earth centric variants
 * Star & Planet ephemeris
   - __Star positions__ for a given observer at a given time (not accounting for proper motion yet)
   - __Planet positions__ for a given observer at a given time (implemented in [CEPlanet](http://jvinniec.github.io/CppEphem/documentation/html/classCEPlanet.html), see tutorials ce101, ce104, planetephem.cpp, and planetpositions.cpp)
@@ -59,8 +59,10 @@ executables which can be run from the command line:
   - __mjd2cal__: Modified Julian date to Gregorian calendar date
   - __mjd2jd__: Modified Julian date to Julian date
 * Coordinate conversion routines (all angles are expected in degrees)
+  - __cirs2icrs__: CIRS to ICRS coordinates
   - __cirs2obs__: CIRS to Observed coordinates
   - __cirs2gal__: CIRS to Galactic coordinates
+  - __gal2icrs__: Galactic to ICRS coordinates
   - __gal2cirs__: Galactic to CIRS coordinates
   - __gal2obs__: Galactic to Observed coordinates
   - __obs2cirs__: Observed to CIRS coordinates
@@ -82,25 +84,47 @@ git clone https://github.com/Jvinniec/CppEphem.git CppEphem
 
 Building the code:
 ----------------------------------------------------------
-The code can either be compiled using 'cmake' or autotools. To compile
-via cmake use the following set of commands:
+Once the code is downloaded, the advised method for compiling the code is via `cmake`. To compile via `cmake` use the following instructions:
 
-```bash
-cmake [-Dprefix=/install/dir]
-make
-```
+1. Create a new directory to build the code in. This enables you to create a completely clean build in the future by simply deleting and recreating this directory.
+   ```bash
+   mkdir /build/dir/
+   cd /build/dir/
+   ```
+2. Now run `cmake` with your desired configuration options to build the code:
+   ```bash
+   # configure
+   cmake [-DCMAKE_INSTALL_PREFIX=/install/dir] /path/to/cloned/CppEphem
+   # build (N = number of threads for compilation)
+   cmake --build . -- [-jN]
+   ```
+   NOTE: "-Dprefix=" and "-DCMAKE_INSTALL_PREFIX=" will have equivalent behavior of specifying the directory where the code will be installed into.
 
-NOTE: "-Dprefix=" and "-DCMAKE_INSTALL_PREFIX=" will have equivalent behavior.
-This will create a 'build' directory in the top level directory of the 
-CppEphem distribution and initially put all of the compiled libraries and
-executables in there. Once that's done, you can install the files by running
-
-```bash
-make install
-```
-This will install the headers, executables, and libraries in the default
+   OPTIONAL: You can now test that the code actually works
+   ```bash
+   cmake --build . --target test
+   make test
+   ```
+3. Install the code into the specified installation directory:
+   ```bash
+   cmake --build . --target install
+   ```
+   This will install the headers, executables, and libraries in the default
 installation directories (or alternatively the directory specified in 
-'-Dprefix' during the initial run of cmake).
+'-DCMAKE_INSTALL_PREFIX' during the initial run of cmake). You should make sure to update your `$PATH` and `$(DY)LD_LIBRARY_PATH` if installing the code to a non-standard location:
+   
+   ```bash
+   # On MAC:
+   export PATH=${PATH}:/install/dir/bin
+   export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:/install/dir/lib
+   # On Linux
+   export PATH=${PATH}:/install/dir/bin
+   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/install/dir/lib 
+   ```
+
+
+## Autotools Build
+**NOTE:** *The code has grown to a point where it is no longer feasible to maintain two build systems. Because of this, it has been decided to depricate the autotools build system and remove it in v1.3.*
 
 To install via autotools, you should be able to build the software 
 very easily using the standard "./configure -> make -> make install" 
@@ -111,7 +135,7 @@ the code". Second, make sure that the "configure" file exists in
 the top directory. If not, then do:
 
 ```bash
-. autogen.sh 
+./autogen.sh 
 ```
 
 Third, configure the software (note the "prefix" option is optional):

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,16 @@
 
 dnl Initialize the build system
 dnl DONT FORGET TO CHANGE THE VERSION!
-AC_INIT([CppEphem],[MASTER],[jvinniec <at> gmail.com])
-AC_CONFIG_SRCDIR([CppEphem/src/mjd2jd.cpp],[sofa/20170420/c/src/cal2jd.c])
+
+m4_define([CppEphem_VERSION_MAJOR], [1])
+m4_define([CppEphem_VERSION_MINOR], [2])
+m4_define([CppEphem_VERSION_PATCH], [0])
+m4_define([cppephem_version],
+          [CppEphem_VERSION_MAJOR.CppEphem_VERSION_MINOR.CppEphem_VERSION_PATCH])
+
+AC_INIT([CppEphem],[cppephem_version],[jvinniec <at> gmail.com])
+AC_CONFIG_SRCDIR([cppephem/src/mjd2jd.cpp],[sofa/src/cal2jd.c])
+AC_CONFIG_HEADER([config.h])
 
 echo ""
 echo "================================================="
@@ -11,7 +19,7 @@ echo "================================================="
 
 dnl Run the automake stuff
 AC_CONFIG_MACRO_DIRS([m4])
-AM_INIT_AUTOMAKE([subdir-objects -Wall -Werror])
+AM_INIT_AUTOMAKE([subdir-objects -Wall -Werror foreign])
 
 dnl Make sure there is a c++ compiler installed
 AC_PROG_CC([clang gcc])
@@ -24,10 +32,11 @@ LT_INIT
 
 dnl This variable will be used to specify special compile options
 special_exec=
-CppEphem_CPPFLAGS=
+CppEphem_CPPFLAGS="-DCPPEPHEM_VERSION=\\\""cppephem_version"\\\""
+
 curDir=${PWD}
 
-BUILDSUBDIRS="CppEphem/src test"
+BUILDSUBDIRS="cppephem/src"
 
 dnl #################################
 dnl SOFA PACKAGE OPTIONS
@@ -38,17 +47,11 @@ have_sofa=no
 sofa_external=no
 
 # Set the default sofa directory to the included one
-SOFADIR="${curDir}/sofa/20160503/c/src"
+SOFADIR="${curDir}/sofa/src/"
 
 AC_ARG_WITH([sofa],
 	AS_HELP_STRING([--with-sofa],
 		[directory containing 'sofa.h']))
-#AC_ARG_WITH([sofa-libdir],
-#	AS_HELP_STRING([--with-sofa-libdir],
-#		[directory containing 'libsofa.a']))
-#AC_ARG_WITH([sofa-incdir],
-#	AS_HELP_STRING([--with-sofa-incdir],
-#		[directory containing 'sofa.h']))
 
 dnl The following is true if '--with-sofa' is specified
 if (test "x$with_sofa" != x) && (test -d ${with_sofa}); then
@@ -69,17 +72,6 @@ fi
 dnl Pass the SOFADIR to the makefiles
 AC_SUBST(SOFADIR)
 AC_SUBST(sofalibs)
-dnl Add the include flags and the library search paths
-#LIBS="${sofalibs} ${LIBS}"
-
-dnl Library checks
-#have_sofa=yes
-# AC_CHECK_LIB([sofa_c],[iauJd2cal],
-#	[have_sofa=yes],
-#	[AC_MSG_ERROR([sofa library does not contain 'iauJd2cal']) have_sofa=no])
-#AC_CHECK_LIB([sofa_c],[iauCal2jd],
-#	[have_sofa=yes],
-#	[AC_MSG_ERROR([sofa library does not contain 'iauCal2jd'])])
 
 if test "x${have_sofa}" != xyes; then
    echo "------------------------------------"
@@ -92,6 +84,7 @@ fi
 
 dnl Add the sofa_CXXFLAGS to the variables accessible in Makefiles
 AC_SUBST(sofa_CXXFLAGS)
+AC_SUBST(CppEphem_CPPFLAGS)
 
 dnl Add the BUILDSUBDIRS to the variables accessible in Makefiles
 AC_SUBST(BUILDSUBDIRS)
@@ -104,6 +97,43 @@ dnl #################################
 dnl #################################
 dnl ADDITIONAL OPTIONS FOR '--with-'/'--without-'
 dnl #################################
+
+# Corrections directory
+cecorrfilepath="${datarootdir}/cppephem/"
+cleanup_corrfilepath="rm -r ${cecorrfilepath}"
+
+AC_ARG_WITH([cecorrfilepath],
+	AS_HELP_STRING([--with-cecorrfilepath],
+		[directory corrections files for 'UT1-UTC' and 'TT-UT1']))
+
+# The following is true if '--with-cecorrfilepath' is specified
+if (test "x$with_cecorrfilepath" != x) && (test -d ${with_cecorrfilepath}); then
+   cecorrfilepath="${with_cecorrfilepath}/"
+   cleanup_corrfilepath=""
+fi
+# Add the corrections directory
+CppEphem_CPPFLAGS="${CppEphem_CPPFLAGS} -DCECORRFILEPATH=\\\"${cecorrfilepath}\\\""
+AC_SUBST(cecorrfilepath)
+AC_SUBST(cleanup_corrfilepath)
+
+# Add libcurl support
+curllibs="-lcurl"
+enable_curl=yes
+
+AC_ARG_ENABLE([curl],
+	AS_HELP_STRING([--enable-curl],
+		[disable support for downloading corrections files via libcurl]),
+  [enable_curl=yes], [enable_curl=no])
+
+dnl The following is true if '--enable-curl' is specified
+AS_IF([test "x$enable_curl" = "xno"], [
+  dnl Do the stuff needed for enabling the feature
+  CppEphem_CPPFLAGS="${CppEphem_CPPFLAGS} -DNOCURL"
+  curllibs = ""
+])
+# Add the corrections directory
+CppEphem_CPPFLAGS="${CppEphem_CPPFLAGS} -DCECORRFILEPATH=\\\"${cecorrfilepath}\\\""
+AC_SUBST(curllibs)
 
 
 dnl #################################
@@ -123,13 +153,8 @@ dnl #################################
 dnl Specify the Makefile locations
 dnl #################################
 
-AC_CONFIG_FILES([Makefile sofa/20160503/c/src/Makefile CppEphem/src/Makefile])
+AC_CONFIG_FILES([Makefile sofa/src/Makefile cppephem/src/Makefile])
 
-#AC_CONFIG_FILES([$SOFADIR/Makefile],[],[SOFADIR='$SOFA_default'])
-#AM_CONDITIONAL([SOFA_INTERNAL], [test "x${sofa_external}" != xyes])
-#AM_COND_IF([SOFA_INTERNAL],
-#	[AC_CONFIG_FILES([Makefile $SOFADIR/Makefile],[],[SOFADIR='$CPPEPH_SOFA_default'])],
-#	[AC_CONFIG_FILES([Makefile CppEphem/src/Makefile])])
 dnl 
 AC_OUTPUT
 
@@ -146,6 +171,7 @@ echo \
  CPPFLAGS: ${CPPFLAGS}
  CXXFLAGS: ${CXXFLAGS}
  SOFADIR : ${SOFADIR}
+ Corrections Dir : '${cecorrfilepath}'
 
  Additional compiler flags:
  --------------------------

--- a/cppephem/src/Makefile.am
+++ b/cppephem/src/Makefile.am
@@ -4,37 +4,47 @@
 # Date: April, 2016
 #
 
-AM_CXXFLAGS = -std=c++11 -I../include -I./ $(sofa_CXXFLAGS) -I$(SOFADIR)
-AM_CFLAGS =
+AM_CXXFLAGS = -std=c++11 $(sofa_CXXFLAGS) $(CppEphem_CPPFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir)/cppephem/include \
+              -I$(top_srcdir)/cppephem/support \
+              -I$(SOFADIR) \
+              $(CppEphem_CPPFLAGS)
 
 lib_LTLIBRARIES = libcppephem.la
-libcppephem_la_SOURCES = cppephem/src/CENamespace.cpp \
-                        cppephem/src/CEBody.cpp \
-                        cppephem/src/CECoordinates.cpp \
-                        cppephem/src/CEDate.cpp \
-                        cppephem/src/CEObservation.cpp \
-                        cppephem/src/CEObserver.cpp \
-                        cppephem/src/CEPlanet.cpp \
-                        cppephem/src/CERunningDate.cpp \
-                        cppephem/src/CETime.cpp 
-include_HEADERS = ../cppephem/include/CppEphem.h \
-                        ../cppephem/include/CENamespace.h \
-                        ../cppephem/include/CEBody.h \
-                        ../cppephem/include/CECoordinates.h \
-                        ../cppephem/include/CEDate.h \
-                        ../cppephem/include/CEObservation.h \
-                        ../cppephem/include/CEObserver.h \
-                        ../cppephem/include/CEPlanet.h \
-                        ../cppephem/include/CERunningDate.h \
-                        ../cppephem/include/CETime.h \
-			../cppephem/support/CLOptions.h \
-                        ../cppephem/support/CEExecOptions.h
 
-libcppephem_la_CPPFLAGS = $(CppEphem_CPPFLAGS)
-libcppephem_la_LIBADD=$(LIBS)
-libcppephem_ladir=$(libdir)
+libcppephem_la_SOURCES = CENamespace.cpp \
+                         CEBody.cpp \
+                         CECoordinates.cpp \
+                         CECorrections.cpp \
+                         CEDate.cpp \
+                         CEException.cpp \
+                         CEObservation.cpp \
+                         CEObserver.cpp \
+                         CEPlanet.cpp \
+                         CERunningDate.cpp \
+                         CETime.cpp
 
-bin_PROGRAMS = cal2jd cal2mjd jd2cal jd2mjd mjd2jd mjd2cal cirs2obs cirs2gal icrs2cirs icrs2gal icrs2obs gal2cirs gal2obs obs2cirs obs2icrs obs2gal angsep planetephem
+headers = ../include/CppEphem.h \
+                  ../include/CENamespace.h \
+                  ../include/CEBody.h \
+                  ../include/CECoordinates.h \
+                  ../include/CECorrections.h \
+                  ../include/CEDate.h \
+                  ../include/CEException.h \
+                  ../include/CEObservation.h \
+                  ../include/CEObserver.h \
+                  ../include/CEPlanet.h \
+                  ../include/CERunningDate.h \
+                  ../include/CETime.h
+
+include_HEADERS = $(headers)
+
+#libcppephem_la_CPPFLAGS = $(CppEphem_CPPFLAGS) $(AM_CPPFLAGS)
+#libcppephem_la_CXXFLAGS = $(CppEphem_CPPFLAGS)
+libcppephem_la_LIBADD = $(LIBS) $(sofalibs) $(curllibs)
+libcppephem_ladir = $(libdir)
+
+bin_PROGRAMS = cal2jd cal2mjd jd2cal jd2mjd mjd2jd mjd2cal cirs2icrs cirs2gal cirs2obs icrs2cirs icrs2gal icrs2obs gal2cirs gal2icrs gal2obs obs2cirs obs2icrs obs2gal angsep planetephem
 
 ##########################################
 # DATE CONVERSION EXECUTABLES
@@ -42,33 +52,27 @@ bin_PROGRAMS = cal2jd cal2mjd jd2cal jd2mjd mjd2jd mjd2cal cirs2obs cirs2gal icr
 
 # CALENDAR to JULIAN DATE
 cal2jd_SOURCES = cal2jd.cpp
-cal2jd_LDADD = libcppephem.la $(sofalibs)
-cal2jd_CPPFLAGS = $(CppEphem_CPPFLAGS)
+cal2jd_LDADD = libcppephem.la
 
 # CALENDAR to MODIFIED JULIAN DATE
 cal2mjd_SOURCES = cal2mjd.cpp
 cal2mjd_LDADD = libcppephem.la
-cal2mjd_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 # JULIAN DATE to CALENDAR
 jd2cal_SOURCES = jd2cal.cpp
 jd2cal_LDADD = libcppephem.la
-jd2cal_CPPFLAGS=$(CppEphem_CPPFLAGS)
 
 # JULIAN DATE to MODIFIED JULIAN DATE
 jd2mjd_SOURCES = jd2mjd.cpp
 jd2mjd_LDADD = libcppephem.la
-jd2mjd_CPPFLAGS=$(CppEphem_CPPFLAGS)
 
 # MODIFIED JULIAN DATE to JULIAN DATE
 mjd2jd_SOURCES = mjd2jd.cpp 
 mjd2jd_LDADD = libcppephem.la
-mjd2jd_CPPFLAGS=$(CppEphem_CPPFLAGS)
 
 # MODIFIED JULIAN DATE to CALENDAR
 mjd2cal_SOURCES = mjd2cal.cpp
 mjd2cal_LDADD = libcppephem.la
-mjd2cal_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 ##########################################
 # TIME CONVERSION EXECUTABLES
@@ -79,55 +83,53 @@ mjd2cal_CPPFLAGS = $(CppEphem_CPPFLAGS)
 # COORDINATE CONVERSION EXECUTABLES
 ##########################################
 
-# CIRS to LOCAL coordinates
-cirs2obs_SOURCES = cirs2obs.cpp
-cirs2obs_LDADD = libcppephem.la
-cirs2obs_CPPFLAGS = $(CppEphem_CPPFLAGS)
+# CIRS to ICRS coordinates
+cirs2icrs_SOURCES = cirs2icrs.cpp
+cirs2icrs_LDADD = libcppephem.la
 
 # CIRS to GALACTIC coordinates
 cirs2gal_SOURCES = cirs2gal.cpp
 cirs2gal_LDADD = libcppephem.la
-cirs2gal_CPPFLAGS = $(CppEphem_CPPFLAGS)
+
+# CIRS to LOCAL coordinates
+cirs2obs_SOURCES = cirs2obs.cpp
+cirs2obs_LDADD = libcppephem.la
 
 # CIRS to LOCAL coordinates
 icrs2obs_SOURCES = icrs2obs.cpp
 icrs2obs_LDADD = libcppephem.la
-icrs2obs_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 # CIRS to GALACTIC coordinates
 icrs2gal_SOURCES = icrs2gal.cpp
 icrs2gal_LDADD = libcppephem.la
-icrs2gal_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 # CIRS to GALACTIC coordinates
 icrs2cirs_SOURCES = icrs2cirs.cpp
 icrs2cirs_LDADD = libcppephem.la
-icrs2cirs_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 # GALACTIC to CIRS coordinates
 gal2cirs_SOURCES = gal2cirs.cpp
 gal2cirs_LDADD = libcppephem.la
-gal2cirs_CPPFLAGS = $(CppEphem_CPPFLAGS)
+
+# GALACTIC to ICRS coordinates
+gal2icrs_SOURCES = gal2icrs.cpp
+gal2icrs_LDADD = libcppephem.la
 
 # GALACTIC to LOCAL coordinates
 gal2obs_SOURCES = gal2obs.cpp
 gal2obs_LDADD = libcppephem.la
-gal2obs_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 # LOCAL to CIRS coordinates
 obs2cirs_SOURCES = obs2cirs.cpp
 obs2cirs_LDADD = libcppephem.la
-obs2cirs_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 # LOCAL to ICRS coordinates
 obs2icrs_SOURCES = obs2icrs.cpp
 obs2icrs_LDADD = libcppephem.la
-obs2icrs_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 # LOCAL to GALACTIC coordinates
 obs2gal_SOURCES = obs2gal.cpp
 obs2gal_LDADD = libcppephem.la
-obs2gal_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 ##########################################
 # ANGULAR SEPARATION
@@ -135,7 +137,6 @@ obs2gal_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 angsep_SOURCES = angsep.cpp
 angsep_LDADD = libcppephem.la
-angsep_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 ##########################################
 # PLANET EPHEMERIS EXECUTABLES
@@ -143,6 +144,5 @@ angsep_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 planetephem_SOURCES = planetephem.cpp
 planetephem_LDADD = libcppephem.la
-planetephem_CPPFLAGS = $(CppEphem_CPPFLAGS)
 
 CLEANFILES=

--- a/sofa/src/Makefile.am
+++ b/sofa/src/Makefile.am
@@ -1,9 +1,10 @@
 ## Process this file with automake to produce Makefile.in
 #
-# Author: J. V. Cardenzana, jvinniec <at> gmail.com
-# 2016-2019
+# Author: Josh V. Cardenzana, jvinniec <at> gmail.com
+# Date: April, 2016
 #
 
+#AM_CXXFLAGS = -std=c++11 -I../include -I./ $(sofa_CXXFLAGS) -I$(SOFADIR)
 AM_CFLAGS = -I./
 
 lib_LTLIBRARIES = libsofa_c.la


### PR DESCRIPTION
This PR fixes the autotools build system. I.e. it fixes compilation for those who prefer to use the standard: 
```bash
./autogen.sh
./configure [--prefix=/install/directory/]
make
make install
```

For those who prefer CMake, this PR fixes the installation of the header files into the 'include' directory under the installation directory.