### PR TITLE
Add CEAngle class

### DIFF
--- a/cppephem/CMakeLists.txt
+++ b/cppephem/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include
 #------------------------------------------
 set (cppephem_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CENamespace.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/CEAngle.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CEBody.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CECoordinates.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CECorrections.cpp
@@ -28,6 +29,7 @@ set (cppephem_SOURCES
 set (cppephem_HEADERS
     include/CppEphem.h
     include/CENamespace.h
+    include/CEAngle.h
     include/CEBody.h
     include/CECoordinates.h
     include/CECorrections.h

--- a/cppephem/include/CEAngle.h
+++ b/cppephem/include/CEAngle.h
@@ -22,6 +22,9 @@
 #ifndef CEAngle_h
 #define CEAngle_h
 
+#include <string> 
+#include <vector>
+
 #include "CENamespace.h"
 
 enum class CEAngleType 
@@ -36,7 +39,8 @@ class CEAngle {
 public:
     // Constructors
     CEAngle();
-    explicit CEAngle(const CEAngle& other);
+    CEAngle(const double& angle);
+    CEAngle(const CEAngle& other);
     virtual ~CEAngle();
 
     // Copy-assignment operators
@@ -47,11 +51,11 @@ public:
     operator double();
     operator double() const;
 
-    static double Hms(const std::string& angle_str, 
-                       const char&        delim=0);
+    static double Hms(const char* angle_str, 
+                      const char& delim=0);
     static double Hms(const std::vector<double>& angle_vec);
-    static double Dms(const std::string& angle_str, 
-                       const char&        delim=0);
+    static double Dms(const char* angle_str, 
+                      const char& delim=0);
     static double Dms(const std::vector<double>& angle_vec);
 
     // Create from an angle value
@@ -69,7 +73,7 @@ public:
     // Generic methods for setting the angle
     void SetAngle(const double&      angle,
                   const CEAngleType& angle_type=CEAngleType::RADIANS);
-    void SetAngle(const std::string& angle_str,
+    void SetAngle(const char*        angle_str,
                   const CEAngleType& angle_type,
                   const char&        delim=0);
     void SetAngle(const std::vector<double>& angle_vec,

--- a/cppephem/include/CEAngle.h
+++ b/cppephem/include/CEAngle.h
@@ -1,0 +1,87 @@
+/***************************************************************************
+ *  CEAngle.h: CppEphem                                                    *
+ * ----------------------------------------------------------------------- *
+ *  Copyright © 2019 JCardenzana                                           *
+ * ----------------------------------------------------------------------- *
+ *                                                                         *
+ *  This program is free software: you can redistribute it and/or modify   *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation, either version 3 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  This program is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *  You should have received a copy of the GNU General Public License      *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef CEAngle_h
+#define CEAngle_h
+
+#include "CENamespace.h"
+
+enum class CEAngleType 
+{
+    DEGREES=0, 
+    RADIANS=1,
+    HMS=2,
+    DMS=3
+};
+
+class CEAngle {
+public:
+    // Constructors
+    CEAngle();
+    explicit CEAngle(const CEAngle& other);
+    virtual ~CEAngle();
+
+    // Copy-assignment operators
+    CEAngle& operator=(const CEAngle& other);
+
+    // Make sure the angle object can be interpreted as a double
+    operator double();
+    operator double() const;
+
+    static CEAngle Hms(const std::string& angle, const char& delim=0);
+    static CEAngle Hms(const std::vector<double>& angle);
+    static CEAngle Dms(const std::string& angle, const char& delim=0);
+    static CEAngle Dms(const std::vector<double>& angle);
+
+    // Create from an angle value
+    static CEAngle Deg(const double& angle);
+    static CEAngle Rad(const double& angle);
+
+    // Methods to return a formatted value for the angle
+    std::string         HmsStr(const char& delim=':') const;
+    std::vector<double> HmsVect(void) const;
+    std::string         DmsStr(const char& delim=':') const;
+    std::vector<double> DmsVect(void) const;
+    double              Deg(void) const;
+    double              Rad(void) const;
+
+    // Generic methods for setting the angle
+    SetAngle(const double&      angle,
+             const CEAngleType& angle_type=CEAngleType::RADIANS);
+    SetAngle(const std::string& angle,
+             const CEAngleType& angle_type,
+             const char&        delim=0);
+    SetAngle(const std::vector<double>& angle,
+             const CEAngleType&         angle_type);
+
+private:
+
+    // Methods
+    void copy_members(const CEAngle& other);
+    void init_members(void);
+    void free_members(void);
+
+    // Variables
+    mutable double angle_;      ///< Angle stored in radians
+
+};
+
+#endif /* CEAngle_h */

--- a/cppephem/include/CEAngle.h
+++ b/cppephem/include/CEAngle.h
@@ -41,19 +41,22 @@ public:
 
     // Copy-assignment operators
     CEAngle& operator=(const CEAngle& other);
+    CEAngle& operator=(const double&  other);
 
     // Make sure the angle object can be interpreted as a double
     operator double();
     operator double() const;
 
-    static CEAngle Hms(const std::string& angle, const char& delim=0);
-    static CEAngle Hms(const std::vector<double>& angle);
-    static CEAngle Dms(const std::string& angle, const char& delim=0);
-    static CEAngle Dms(const std::vector<double>& angle);
+    static double Hms(const std::string& angle_str, 
+                       const char&        delim=0);
+    static double Hms(const std::vector<double>& angle_vec);
+    static double Dms(const std::string& angle_str, 
+                       const char&        delim=0);
+    static double Dms(const std::vector<double>& angle_vec);
 
     // Create from an angle value
-    static CEAngle Deg(const double& angle);
-    static CEAngle Rad(const double& angle);
+    static double Deg(const double& angle);
+    static double Rad(const double& angle);
 
     // Methods to return a formatted value for the angle
     std::string         HmsStr(const char& delim=':') const;
@@ -64,13 +67,13 @@ public:
     double              Rad(void) const;
 
     // Generic methods for setting the angle
-    SetAngle(const double&      angle,
-             const CEAngleType& angle_type=CEAngleType::RADIANS);
-    SetAngle(const std::string& angle,
-             const CEAngleType& angle_type,
-             const char&        delim=0);
-    SetAngle(const std::vector<double>& angle,
-             const CEAngleType&         angle_type);
+    void SetAngle(const double&      angle,
+                  const CEAngleType& angle_type=CEAngleType::RADIANS);
+    void SetAngle(const std::string& angle_str,
+                  const CEAngleType& angle_type,
+                  const char&        delim=0);
+    void SetAngle(const std::vector<double>& angle_vec,
+                  const CEAngleType&         angle_type);
 
 private:
 

--- a/cppephem/include/CEAngle.h
+++ b/cppephem/include/CEAngle.h
@@ -51,16 +51,16 @@ public:
     operator double();
     operator double() const;
 
-    static double Hms(const char* angle_str, 
+    static CEAngle Hms(const char* angle_str, 
                       const char& delim=0);
-    static double Hms(const std::vector<double>& angle_vec);
-    static double Dms(const char* angle_str, 
+    static CEAngle Hms(const std::vector<double>& angle_vec);
+    static CEAngle Dms(const char* angle_str, 
                       const char& delim=0);
-    static double Dms(const std::vector<double>& angle_vec);
+    static CEAngle Dms(const std::vector<double>& angle_vec);
 
     // Create from an angle value
-    static double Deg(const double& angle);
-    static double Rad(const double& angle);
+    static CEAngle Deg(const double& angle);
+    static CEAngle Rad(const double& angle);
 
     // Methods to return a formatted value for the angle
     std::string         HmsStr(const char& delim=':') const;

--- a/cppephem/include/CEAngle.h
+++ b/cppephem/include/CEAngle.h
@@ -86,6 +86,9 @@ private:
     void init_members(void);
     void free_members(void);
 
+    void SetAngle_HmsVect(const std::vector<double>& angle);
+    void SetAngle_DmsVect(const std::vector<double>& angle);
+
     // Variables
     mutable double angle_;      ///< Angle stored in radians
 

--- a/cppephem/include/CEAngle.h
+++ b/cppephem/include/CEAngle.h
@@ -40,7 +40,7 @@ public:
     // Constructors
     CEAngle();
     CEAngle(const double& angle);
-    CEAngle(const CEAngle& other);
+    explicit CEAngle(const CEAngle& other);
     virtual ~CEAngle();
 
     // Copy-assignment operators

--- a/cppephem/include/CEBody.h
+++ b/cppephem/include/CEBody.h
@@ -43,12 +43,14 @@ public:
      ***********************************/
 
     CEBody() ;
-    CEBody(const std::string& name, 
-           const double& xcoord, const double& ycoord,
-           const CECoordinateType& coord_type = CECoordinateType::ICRS,
-           const CEAngleType& angle_type=CEAngleType::RADIANS) ;
-    CEBody(const CEBody& other, const std::string& name="") ;
-    CEBody(const CECoordinates& coords, const std::string& name="") ;
+    CEBody(const std::string&      name, 
+           const CEAngle&          xcoord, 
+           const CEAngle&          ycoord,
+           const CECoordinateType& coord_type = CECoordinateType::ICRS) ;
+    CEBody(const CEBody&      other, 
+           const std::string& name="") ;
+    CEBody(const CECoordinates& coords, 
+           const std::string&   name="") ;
     virtual ~CEBody() ;
     
     /************************************

--- a/cppephem/include/CECoordinates.h
+++ b/cppephem/include/CECoordinates.h
@@ -405,7 +405,7 @@ private:
 
 
 /**********************************************************************//**
- * Return x coordinate at given Julian date in radius
+ * Return x coordinate at given Julian date in radians
  * 
  * @param[in] jd   Julian date (used only by derived classes)
  * @return X-coordinate in radians
@@ -431,7 +431,7 @@ double CECoordinates::XCoordinate_Deg(double jd) const
 
 
 /**********************************************************************//**
- * Returns y coordinate at given Julian date in radius
+ * Returns y coordinate at given Julian date in radians
  * 
  * @param[in] jd   Julian date (used only by derived classes)
  * @return Y-coordinate in radians

--- a/cppephem/include/CECoordinates.h
+++ b/cppephem/include/CECoordinates.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 // CppEphem HEADERS
+#include "CEAngle.h"
 #include "CEDate.h"
 #include "CENamespace.h"
 #include "CEException.h"

--- a/cppephem/include/CECoordinates.h
+++ b/cppephem/include/CECoordinates.h
@@ -437,7 +437,7 @@ CEAngle CECoordinates::YCoord(const double& jd) const
 inline
 double CECoordinates::XCoordinate_Rad(double jd) const
 {
-    return xcoord_;
+    return XCoord(jd).Rad();
 }
 
 
@@ -450,7 +450,7 @@ double CECoordinates::XCoordinate_Rad(double jd) const
 inline
 double CECoordinates::XCoordinate_Deg(double jd) const
 {
-    return XCoordinate_Rad(jd) * DR2D;
+    return XCoord(jd).Deg();
 }
 
 
@@ -463,7 +463,7 @@ double CECoordinates::XCoordinate_Deg(double jd) const
 inline
 double CECoordinates::YCoordinate_Rad(double jd) const
 {
-    return ycoord_;
+    return YCoord(jd).Rad();
 }
     
 /**********************************************************************//**
@@ -475,7 +475,7 @@ double CECoordinates::YCoordinate_Rad(double jd) const
 inline
 double CECoordinates::YCoordinate_Deg(double jd) const
 {
-    return YCoordinate_Rad(jd) * DR2D;
+    return YCoord(jd).Deg();
 }
 
 

--- a/cppephem/include/CECoordinates.h
+++ b/cppephem/include/CECoordinates.h
@@ -70,16 +70,13 @@ public:
     /*********************************************************
      * Angular separation between two coordinate positions
      *********************************************************/
-    virtual double AngularSeparation(const CECoordinates& coords,
-                                     const CEAngleType& return_angle_type=CEAngleType::DEGREES) const;
-    static double AngularSeparation(const CECoordinates& coords1, 
-                                    const CECoordinates& coords2,
-                                    const CEAngleType& return_angle_type=CEAngleType::DEGREES);
-    static double AngularSeparation(double xcoord_first, 
-                                    double ycoord_first,
-                                    double xcoord_second, 
-                                    double ycoord_second,
-                                    const CEAngleType& angle_type=CEAngleType::DEGREES);
+    virtual CEAngle AngularSeparation(const CECoordinates& coords) const;
+    static CEAngle AngularSeparation(const CECoordinates& coords1, 
+                                     const CECoordinates& coords2);
+    static CEAngle AngularSeparation(const CEAngle& xcoord_first, 
+                                     const CEAngle& ycoord_first,
+                                     const CEAngle& xcoord_second, 
+                                     const CEAngle& ycoord_second);
     
     /**********************************************************
      * Methods for accessing the coordinate information

--- a/cppephem/include/CECoordinates.h
+++ b/cppephem/include/CECoordinates.h
@@ -55,10 +55,9 @@ public:
 
     /****** CONSTRUCTORS ******/
     CECoordinates() ;
-    CECoordinates(const double& xcoord, 
-                  const double& ycoord,
-                  const CECoordinateType& coord_type=CECoordinateType::ICRS,
-                  const CEAngleType& angle_type=CEAngleType::RADIANS) ;
+    CECoordinates(const CEAngle& xcoord, 
+                  const CEAngle& ycoord,
+                  const CECoordinateType& coord_type=CECoordinateType::ICRS) ;
     CECoordinates(const std::vector<double>& xcoord,
                   const std::vector<double>& ycoord,
                   const CECoordinateType& coord_type=CECoordinateType::ICRS);
@@ -86,6 +85,10 @@ public:
      * Methods for accessing the coordinate information
      **********************************************************/
     
+    virtual CEAngle XCoord(const double& jd=CppEphem::julian_date_J2000()) const;
+    virtual CEAngle YCoord(const double& jd=CppEphem::julian_date_J2000()) const;
+
+    // The following methods will be depricated in the future
     virtual double XCoordinate_Rad(double jd=CppEphem::julian_date_J2000()) const;
     virtual double XCoordinate_Deg(double jd=CppEphem::julian_date_J2000()) const;
     virtual double YCoordinate_Rad(double jd=CppEphem::julian_date_J2000()) const;
@@ -378,21 +381,19 @@ public:
     /*********************************************************
      * Methods for setting the coordinates of this object
      *********************************************************/
-    virtual void SetCoordinates(const double& xcoord, 
-                                const double& ycoord,
-                                const CECoordinateType& coord_type = CECoordinateType::ICRS,
-                                const CEAngleType& angle_type = CEAngleType::RADIANS);
+    virtual void SetCoordinates(const CEAngle& xcoord, 
+                                const CEAngle& ycoord,
+                                const CECoordinateType& coord_type = CECoordinateType::ICRS);
     virtual void SetCoordinates(const CECoordinates& coords);
 
     // Support methods
     std::string print(void) const;
-    
+
 protected:
     // Coordinate variables
-    mutable double xcoord_;         //<! X coordinate (radians)
-    mutable double ycoord_;         //<! Y coordinate (radians)
+    mutable CEAngle xcoord_;        //<! X coordinate
+    mutable CEAngle ycoord_;        //<! Y coordinate
     CECoordinateType coord_type_;   //<! Coordinate system to which 'xcoord_' and 'ycoord_' belong.
-                                    //<! Possible values are "CIRS", "ICRS", "GALACTIC", "OBSERVED", and "GEOGRAPHIC" 
 
 private:
     /*********************************************************
@@ -402,6 +403,32 @@ private:
     void free_members(void);
     void init_members(void);
 };
+
+
+/**********************************************************************//**
+ * Return x coordinate at given Julian date
+ * 
+ * @param[in] jd   Julian date (used only by derived classes)
+ * @return X-coordinate as a CEAngle
+ *************************************************************************/
+inline
+CEAngle CECoordinates::XCoord(const double& jd) const
+{
+    return xcoord_;
+}
+
+
+/**********************************************************************//**
+ * Return y coordinate at given Julian date
+ * 
+ * @param[in] jd   Julian date (used only by derived classes)
+ * @return X-coordinate as a CEAngle
+ *************************************************************************/
+inline
+CEAngle CECoordinates::YCoord(const double& jd) const
+{
+    return ycoord_;
+}
 
 
 /**********************************************************************//**

--- a/cppephem/include/CEException.h
+++ b/cppephem/include/CEException.h
@@ -77,6 +77,13 @@ public:
                           const std::string& message);
     };
 
+    // Invalid delimiter
+    class invalid_delimiter : public CEExceptionHandler {
+        public:
+            invalid_delimiter(const std::string& origin,
+                              const std::string& message);
+    };
+
     /* ----------------------------------------------------------- *
      *        EXCEPTIONS RELATED TO READING CORRECTIONS FILE
      * ----------------------------------------------------------- */

--- a/cppephem/include/CENamespace.h
+++ b/cppephem/include/CENamespace.h
@@ -28,11 +28,6 @@
 #include <memory>
 #include "CECorrections.h"
 
-enum class CEAngleType 
-{
-    DEGREES=0, 
-    RADIANS=1
-};
 
 // Create a namespace with some useful stuff
 namespace CppEphem {
@@ -101,6 +96,24 @@ namespace CppEphem {
     void        SetTtUt1PredFile(const std::string& filename);
     void        CorrectionsInterp(bool set_interp);
     static      CECorrections corrections;
+
+    namespace StrOpt {
+        // Method for splitting a string based on some delimiter into a vector of strings
+        inline std::vector<std::string>& split(const std::string &s, char delim, std::vector<std::string> &elems) {
+            std::stringstream ss(s);
+            std::string item=std::string();
+            while (std::getline(ss, item, delim)) {
+                elems.push_back(item);
+            }
+            return elems;
+        }
+        // Method for splitting a string based on some delimiter into a vector of strings
+        inline std::vector<std::string> split(const std::string &s, char delim) {
+            std::vector<std::string> elems;
+            split(s, delim, elems);
+            return elems;
+        }
+    }
 }
 
 #endif /* CENamespace_h */

--- a/cppephem/include/CENamespace.h
+++ b/cppephem/include/CENamespace.h
@@ -99,20 +99,11 @@ namespace CppEphem {
 
     namespace StrOpt {
         // Method for splitting a string based on some delimiter into a vector of strings
-        inline std::vector<std::string>& split(const std::string &s, char delim, std::vector<std::string> &elems) {
-            std::stringstream ss(s);
-            std::string item=std::string();
-            while (std::getline(ss, item, delim)) {
-                elems.push_back(item);
-            }
-            return elems;
-        }
-        // Method for splitting a string based on some delimiter into a vector of strings
-        inline std::vector<std::string> split(const std::string &s, char delim) {
-            std::vector<std::string> elems;
-            split(s, delim, elems);
-            return elems;
-        }
+        void                     split(const std::string&        s, 
+                                       const char&               delim, 
+                                       std::vector<std::string>& elems);
+        std::vector<std::string> split(const std::string& s, 
+                                       const char&        delim);
     }
 }
 

--- a/cppephem/include/CENamespace.h
+++ b/cppephem/include/CENamespace.h
@@ -101,9 +101,16 @@ namespace CppEphem {
         // Method for splitting a string based on some delimiter into a vector of strings
         void                     split(const std::string&        s, 
                                        const char&               delim, 
-                                       std::vector<std::string>& elems);
+                                       std::vector<std::string>* elems);
         std::vector<std::string> split(const std::string& s, 
                                        const char&        delim);
+
+        // Join strings using a set delimiter
+        template<typename T>
+        std::string join(const std::vector<T>& values,
+                         const char&           delim);
+        std::string join_angle(const std::vector<double>& values,
+                               const char&                delim);
     }
 }
 

--- a/cppephem/include/CEPlanet.h
+++ b/cppephem/include/CEPlanet.h
@@ -37,10 +37,9 @@ class CEPlanet : public CEBody {
 public:
     CEPlanet() ;
     CEPlanet(const std::string&      name, 
-             const double&           xcoord, 
-             const double&           ycoord,
-             const CECoordinateType& coord_type=CECoordinateType::CIRS,
-             const CEAngleType&      angle_type=CEAngleType::RADIANS) ;
+             const CEAngle&          xcoord, 
+             const CEAngle&          ycoord,
+             const CECoordinateType& coord_type=CECoordinateType::CIRS) ;
     CEPlanet(const CEPlanet& other);
     virtual ~CEPlanet() ;
     

--- a/cppephem/src/CEAngle.cpp
+++ b/cppephem/src/CEAngle.cpp
@@ -29,8 +29,6 @@
  */
 
 #include <algorithm>
-#include <iomanip>
-#include <sstream>
 
 #include "CEAngle.h"
 #include "CEException.h"
@@ -182,22 +180,9 @@ std::string CEAngle::HmsStr(const char& delim) const
 {
     // Get the angle as a vector
     std::vector<double> hms_d = HmsVect();
-    
-    // Make sure there are only three values
-    if (hms_d.size() == 4) {
-        hms_d[2] += hms_d[3];
-    }
 
     // Assemble the string using the specified delimiter
-    std::ostringstream ss;
-    ss << std::setfill('0') << std::setw(2) << int(hms_d[0]);
-    ss << delim;
-    ss << std::setfill('0') << std::setw(2) << int(hms_d[1]);
-    ss << delim;
-    ss << std::setfill('0') << std::setw(11) << std::fixed 
-       << std::setprecision(8) << hms_d[2];
-    
-    return std::string(ss.str());
+    return CppEphem::StrOpt::join_angle(hms_d, delim);
 }
 
 
@@ -288,22 +273,8 @@ std::string CEAngle::DmsStr(const char& delim) const
     // Get the angle as a vector
     std::vector<double> dms_d = DmsVect();
     
-    // Make sure there are only three values
-    if (dms_d.size() == 4) {
-        dms_d[2] += dms_d[3];
-    }
-
-    // Assemble the string using teh specified delimiter
     // Assemble the string using the specified delimiter
-    std::ostringstream ss;
-    ss << std::setfill('0') << std::setw(2) << int(dms_d[0]);
-    ss << delim;
-    ss << std::setfill('0') << std::setw(2) << int(dms_d[1]);
-    ss << delim;
-    ss << std::setfill('0') << std::setw(11) << std::fixed 
-       << std::setprecision(8) << dms_d[2];
-    
-    return std::string(ss.str());
+    return CppEphem::StrOpt::join_angle(dms_d, delim);
 }
 
 
@@ -443,7 +414,7 @@ void CEAngle::SetAngle(const char*        angle_str,
         if (delim != 0) {
 
             // Split the string
-            CppEphem::StrOpt::split(angle_str, delim, angle_vec);
+            CppEphem::StrOpt::split(angle_str, delim, &angle_vec);
 
             // Throw an error if the string was not properly split
             if (angle_vec.size() < 3) {

--- a/cppephem/src/CEAngle.cpp
+++ b/cppephem/src/CEAngle.cpp
@@ -140,12 +140,12 @@ CEAngle::operator double() const
  *      * ' ' = 'HH MM SS'
  *      * <any char> = The DD, MM, SS is separated by a user defined char
  *************************************************************************/
-double CEAngle::Hms(const char* angle_str, 
-                    const char& delim)
+CEAngle CEAngle::Hms(const char* angle_str, 
+                     const char& delim)
 {
     CEAngle angle;
     angle.SetAngle(angle_str, CEAngleType::HMS, delim);
-    return angle.Rad();
+    return angle;
 }
 
 
@@ -162,11 +162,11 @@ double CEAngle::Hms(const char* angle_str,
  *      [3] = (optional) seconds fraction
  * The index [3] is optional if index [2] contains the whole seconds portion
  *************************************************************************/
-double CEAngle::Hms(const std::vector<double>& angle_vec)
+CEAngle CEAngle::Hms(const std::vector<double>& angle_vec)
 {
     CEAngle angle;
     angle.SetAngle(angle_vec, CEAngleType::HMS);
-    return angle.Rad();
+    return angle;
 }
 
 
@@ -232,12 +232,12 @@ std::vector<double> CEAngle::HmsVect(void) const
  *      * ' ' = 'DD MM SS'
  *      * <any char> = The DD, MM, SS is separated by a user defined char
  *************************************************************************/
-double CEAngle::Dms(const char* angle_str, 
-                    const char& delim)
+CEAngle CEAngle::Dms(const char* angle_str, 
+                     const char& delim)
 {
     CEAngle angle;
     angle.SetAngle(angle_str, CEAngleType::DMS, delim);
-    return angle.Rad();
+    return angle;
 }
 
 
@@ -254,11 +254,11 @@ double CEAngle::Dms(const char* angle_str,
  *      [3] = (optional) seconds fraction
  * The index [3] is optional if index [2] contains the whole seconds portion
  *************************************************************************/
-double CEAngle::Dms(const std::vector<double>& angle_vec)
+CEAngle CEAngle::Dms(const std::vector<double>& angle_vec)
 {
     CEAngle angle;
     angle.SetAngle(angle_vec, CEAngleType::DMS);
-    return angle.Rad();
+    return angle;
 }
 
 
@@ -272,7 +272,7 @@ std::string CEAngle::DmsStr(const char& delim) const
 {
     // Get the angle as a vector
     std::vector<double> dms_d = DmsVect();
-    
+
     // Assemble the string using the specified delimiter
     return CppEphem::StrOpt::join_angle(dms_d, delim);
 }
@@ -315,7 +315,7 @@ std::vector<double> CEAngle::DmsVect(void) const
  * @param[in] angle             Angle in degrees
  * @return CEAngle object
  *************************************************************************/
-double CEAngle::Deg(const double& angle)
+CEAngle CEAngle::Deg(const double& angle)
 {
     return angle * DD2R;
 }
@@ -338,7 +338,7 @@ double CEAngle::Deg(void) const
  * @param[in] angle             Angle in radians
  * @return Angle constructed from a 'radians' object
  *************************************************************************/
-double CEAngle::Rad(const double& angle)
+CEAngle CEAngle::Rad(const double& angle)
 {
     return angle;
 }
@@ -361,18 +361,22 @@ double CEAngle::Rad(void) const
  * @param[in] angle             Angle value
  * @param[in] angle_type        CEAngleType (only DEGREES or RADIANS are accepted)
  * 
- * An exception is thrown if @p angle_type is neither DEGREES or RADIANS
+ * @exception CEException::invalid_value
+ *            @p angle_type is neither DEGREES nor RADIANS
+ * 
+ * This method calls the SOFA function iauAnp to ensure the angle is in the
+ * range [0, 2pi).
  *************************************************************************/
 void CEAngle::SetAngle(const double&      angle,
                        const CEAngleType& angle_type)
 {
     // Set from degree angle
     if (angle_type == CEAngleType::DEGREES) {
-        angle_ = angle * DD2R;
+        angle_ = iauAnp(angle * DD2R);
     }
     // Set from radians angle
     else if (angle_type == CEAngleType::RADIANS) {
-        angle_ = angle;
+        angle_ = iauAnp(angle);
     }
     // Otherwise throw an exception
     else {

--- a/cppephem/src/CEAngle.cpp
+++ b/cppephem/src/CEAngle.cpp
@@ -1,0 +1,451 @@
+/***************************************************************************
+ *  CEAngle.cpp: CppEphem                                                  *
+ * ----------------------------------------------------------------------- *
+ *  Copyright © 2019 JCardenzana                                           *
+ * ----------------------------------------------------------------------- *
+ *                                                                         *
+ *  This program is free software: you can redistribute it and/or modify   *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation, either version 3 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  This program is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *  You should have received a copy of the GNU General Public License      *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                         *
+ ***************************************************************************/
+
+/** \class CEAngle
+ The CEAngle class defines an angle. It can be constructed either from:
+  * double: representing degrees or radians
+  * string: representing HH:MM:SS or DD:MM:SS
+  
+ Methods are also provided to allow the user to retrieve the angle in whatever
+ format they prefer
+ */
+
+
+#include "CEAngle.h"
+#include "CEException.h"
+
+/**********************************************************************//**
+ * Default constructor
+ *************************************************************************/
+CEAngle::CEAngle()
+{
+    init_members();
+}
+
+
+/**********************************************************************//**
+ * Construct from another CEAngle object
+ * 
+ * @param[in] other         CEAngle to copy data members from
+ * 
+ * By default this method assumes the passed angle is provided in RADIANS
+ *************************************************************************/
+CEAngle::CEAngle(const CEAngle& other)
+{
+    init_members();
+    copy_members(other);
+}
+
+
+/**********************************************************************//**
+ * Destructor
+ *************************************************************************/
+CEAngle::~CEAngle(void)
+{
+    free_members();
+}
+
+
+/**********************************************************************//**
+ * Copy assignment operator
+ * 
+ * @param[in] other         CEAngle object to copy objects from
+ * @return CEAngle object constructed from @p other
+ *************************************************************************/
+CEAngle& CEAngle::operator=(const CEAngle& other)
+{
+    if (this != &other) {
+        free_members();
+        init_members();
+        copy_members(other);
+    }
+    return *this;
+}
+
+
+/**********************************************************************//**
+ * Return a double object representing the angle in radians
+ *************************************************************************/
+CEAngle::operator double()
+{
+    return angle_;
+}
+
+
+/**********************************************************************//**
+ * Return a double object representing the angle in radians
+ *************************************************************************/
+CEAngle::operator double() const
+{
+    return angle_;
+}
+
+
+/**********************************************************************//**
+ * Return CEAngle constructed from a string representing hours, minutes, seconds
+ * 
+ * @param[in] angle             Angle representing hours, minutes, seconds
+ * @param[in] delim             Delimiter, by default all methods will be tested
+ * 
+ * The following values for @p delim are special cases:
+ *      * 0 (int) = tests all following possible values for delimiter
+ *      * ':' = 'HH:MM:SS'
+ *      * ' ' = 'HH MM SS'
+ *      * <any char> = The DD, MM, SS is separated by a user defined char
+ *************************************************************************/
+CEAngle CEAngle::Hms(const std::string& angle, const char& delim=0)
+{
+    CEAngle angle;
+    angle.SetAngle(angle, CEAngleType::HMS, delim);
+    return angle;
+}
+
+
+/**********************************************************************//**
+ * Return CEAngle constructed from a string representing hours, minutes, seconds
+ * 
+ * @param[in] angle             Angle representing hours, minutes, seconds
+ * @return CEAngle object
+ *************************************************************************/
+CEAngle CEAngle::Hms(const std::vector<double>& angle)
+{
+    CEAngle angle;
+    angle.SetAngle(angle, CEAngleType::HMS);
+    return angle;
+}
+
+
+std::string CEAngle::Hms(const char& delim)
+{
+    // Get the angle as a vector
+
+}
+
+
+/**********************************************************************//**
+ * Return vector of doubles representing the {hours, min, sec, sec-fraction}
+ * 
+ * @return Vector of doubles representing {hours, min, sec, sec-fraction}
+ * 
+ * The returned vector has the following elements
+ *      [0] = hours
+ *      [1] = minutes
+ *      [2] = seconds
+ *      [3] = seconds fraction
+ *************************************************************************/
+std::vector<double> CEAngle::HmsVect(void) const
+{
+    // Stores the resulting values
+    std::vector<int> HMS_i(4);
+
+    // Stores the sign
+    char pm;
+    iauA2tf(9, angle_, &pm, &HMS_i[0]);
+    
+    // Convert the values into doubles
+    std::vector<double> HMS_d(HMS_i.size());
+    // Scale the fraction to be a true fraction
+    HMS_d[0] = double(HMS_i[0]);
+    HMS_d[1] = double(HMS_i[1]);
+    HMS_d[2] = double(HMS_i[2]);
+    HMS_d[3] = double(HMS_i[3])/1.0e9;
+    // Multiply the degree by a negative
+    if (pm == '-') HMS_d[0] *= -1;
+
+    return HMS_d;
+}
+
+
+/**********************************************************************//**
+ * Return CEAngle constructed from a string representing degrees, minutes, seconds
+ * 
+ * @param[in] angle             Angle representing degrees, arcmins, arcsecs
+ * @param[in] delim             Delimiter, by default all methods will be tested
+ * 
+ * The following values for @p delim are special cases:
+ *      * 0 (int) = tests all following possible values for delimiter
+ *      * ':' = 'DD:MM:SS'
+ *      * ' ' = 'DD MM SS'
+ *      * <any char> = The DD, MM, SS is separated by a user defined char
+ *************************************************************************/
+CEAngle CEAngle::Dms(const std::string& angle, const char& delim=0)
+{
+    CEAngle angle;
+    angle.SetAngle(angle, CEAngleType::DMS, delim);
+    return angle;
+}
+
+
+/**********************************************************************//**
+ * Return CEAngle constructed from a string representing degrees, minutes, seconds
+ * 
+ * @param[in] angle             Angle representing degrees, arcmins, arcsecs
+ * @return CEAngle object
+ *************************************************************************/
+CEAngle CEAngle::Dms(const std::vector<double>& angle)
+{
+    CEAngle angle;
+    angle.SetAngle(angle, CEAngleType::DMS);
+    return angle;
+}
+
+
+/**********************************************************************//**
+ * Return vector of doubles representing the {degrees, arcmin, arcsec, arcsec-fraction}
+ * 
+ * @return Vector of doubles representing {degrees, arcmin, arcsec, arcsec-fraction}
+ * 
+ * The returned vector has the following elements
+ *      [0] = degrees
+ *      [1] = arcminutes
+ *      [2] = arcseconds
+ *      [3] = arcseconds fraction
+ *************************************************************************/
+std::vector<double> CEAngle::DmsVect(void) const
+{
+    // Variables for holding the results
+    char sign;
+    std::vector<int> DMS_i(4, 0.0);
+
+    // Run the appropriate SOFA value
+    iauA2af(9, angle_, &sign, &DMS_i[0]);
+
+    // Fill the values into a double vector
+    std::vector<double> DMS_d(4, 0.0);
+    DMS_d[0] = DMS_i[0] * (sign == '-' ? -1.0 : 1.0);
+    DMS_d[1] = DMS_i[1];
+    DMS_d[2] = DMS_i[2];
+    DMS_d[3] = DMS_i[3] * 1.0e-9;
+
+    return DMS_d ;
+}
+
+
+/**********************************************************************//**
+ * Return CEAngle constructed from a degree angle
+ * 
+ * @param[in] angle             Angle in degrees
+ * @return CEAngle object
+ *************************************************************************/
+CEAngle CEAngle::Deg(const double& angle)
+{
+    return CEAngle(angle*DD2R);
+}
+
+
+/**********************************************************************//**
+ * Return angle in degrees as a double
+ * 
+ * @return Angle in degrees as a double
+ *************************************************************************/
+double CEAngle::Deg(void)
+{
+    return angle_ * DR2D;
+}
+
+
+/**********************************************************************//**
+ * Return CEAngle constructed from a radians angle
+ * 
+ * @param[in] angle             Angle in radians
+ * @return CEAngle object
+ *************************************************************************/
+CEAngle CEAngle::Rad(const double& angle)
+{
+    return CEAngle(angle);
+}
+
+
+/**********************************************************************//**
+ * Return angle in radians as a double
+ * 
+ * @return Angle in radians as a double
+ *************************************************************************/
+double CEAngle::Rad(void)
+{
+    return angle_;
+}
+
+
+/**********************************************************************//**
+ * Set the angle from a double
+ * 
+ * @param[in] angle             Angle value
+ * @param[in] angle_type        CEAngleType (only DEGREES or RADIANS are accepted)
+ * 
+ * An exception is thrown if @p angle_type is neither DEGREES or RADIANS
+ *************************************************************************/
+void CEAngle::SetAngle(const double&      angle,
+                       const CEAngleType& angle_type)
+{
+    // Set from degree angle
+    if (angle_type == CEAngleType::DEGREES) {
+        angle_ = angle * DD2R;
+    }
+    // Set from radians angle
+    else if (angle_type == CEAngleType::RADIANS) {
+        angle_ = angle;
+    }
+    // Otherwise throw an exception
+    else {
+        throw CEException::invalid_value(
+            "CEAngle::SetAngle(const double&, const CEAngleType&)",
+            "[ERROR] Method cannot be called with the provided CEAngleType");
+    }
+
+    return;
+}
+
+
+/**********************************************************************//**
+ * Set the angle from a string representing either HMS or DMS angles
+ * 
+ * @param[in] angle             Angle represented by a HMS or DMS string
+ * @param[in] angle_type        CEAngleType (only HMS or DMS are accepted)
+ * @param[in] delim             Delimiter used to separate different components in @p angle
+ * 
+ * An exception is thrown if @p angle_type is neither HMS or DMS
+ *************************************************************************/
+void CEAngle::SetAngle(const std::string& angle,
+                       const CEAngleType& angle_type,
+                       const char&        delim)
+{
+    // Angle is a degree or radian
+    if ((angle_type == CEAngleType::DEGREES) || (angle_type == CEAngleType::RADIANS)) {
+        SetAngle(std::stod(angle), angle_type);
+    }
+
+    // Otherwise the angle is a delimited string (i.e. something like HH:MM:SS)
+    else {
+        // Create a string vector to hold the parsed values
+        std::vector<std::string> angle_str;
+        angle_str.reserve(4);
+
+        // Handle specific delimitors
+        if (int(delim) != 0) {
+            // Split the string
+            CppEphem::StrOpt::split(angle, delim, angle_str);
+            if (angle_str.size() < 3) {
+                throw CEException::invalid_value(
+                    "CEAngle::SetAngle(const string&, const CEAngleType&, const char&)",
+                    "[ERROR] Could not find specified delimiter: " + std::string(delim));
+            }
+        } 
+        
+        // Handle delimiter agnostic format
+        else if (int(delim) == 0) {
+            // Create vector of delimiters to be tried
+            std::vector<char> delim_list = {':', ' '};
+            bool success = false;
+            for (auto& d : delim_list) {
+                try {
+                    // Try to set the angle
+                    SetAngle(angle, angle_type, d);
+                    success = true;
+                    break;
+                } catch (CEException::invalid_value& e) {
+                    // Failed
+                }
+            }
+
+            // Make sure setting the angle was a success
+            if (!success) {
+                throw CEException::invalid_value(
+                    "CEAngle::SetAngle(const string&, const CEAngleType&, const char&)",
+                    "[ERROR] Unable to parse angle string");
+            }
+        }
+
+        // Now format the string in the appropriate way
+        std::vector<double> angle_dbl(angle_str.size());
+    }
+
+    return;
+}
+
+
+/**********************************************************************//**
+ * Set the angle from a vector of doubles
+ * 
+ * @param[in] angle             Angle as a vector of doubles
+ * @param[in] angle_type        CEAngleType (only HMS or DMS are accepted)
+ * 
+ * An exception is thrown if @p angle_type is neither HMS or DMS
+ *************************************************************************/
+void CEAngle::SetAngle(const std::vector<double>& angle,
+                       const CEAngleType&         angle_type)
+{
+    // Throw an error if the provided angle type does not make sense
+    if ((angle_type != CEAngleType::HMS) || (angle_type != CEAngleType::DMS)) {
+        throw CEException::invalid_value(
+            "CEAngle::SetAngle(const std::vector&, const CEAngleType&)",
+            "[ERROR] Method cannot be called with the provided CEAngleType");
+    }
+
+    // Construct the angle as the sum of the different components
+    double full_ang( std::fabs(angle[0]) );
+    full_ang += std::fabs(angle[1]) / 60.0;
+    full_ang += std::fabs(angle[2]) / 3600.0;
+
+    // In case the angle has been 
+    if (angle.size() == 4) {
+        full_ang += std::fabs(angle[3]) / 3600.0;
+    }
+
+    // Scale the angle from hours to degrees
+    if (angle_type == CEAngleType::HMS) {
+        full_ang *= 15.0;
+    }
+
+    // Set the angle
+    SetAngle(full_ang, CEAngleType::DEGREES);
+    return;
+}
+
+
+/**********************************************************************//**
+ * Free allocated data members
+ *************************************************************************/
+void CEAngle::free_members(void)
+{
+    // Nothing to do here
+    return;
+}
+
+
+/**********************************************************************//**
+ * Copy data members from another CEAngle object
+ * 
+ * @param[in] other         CEAngle object to copy from
+ *************************************************************************/
+void CEAngle::copy_members(const CEAngle& other)
+{
+    angle_ = other.angle_;
+}
+
+
+/**********************************************************************//**
+ * Initialize data members
+ *************************************************************************/
+void CEAngle::init_members(void)
+{
+    angle_ = 0.0;
+}

--- a/cppephem/src/CEAngle.cpp
+++ b/cppephem/src/CEAngle.cpp
@@ -489,7 +489,10 @@ void CEAngle::SetAngle(const std::vector<double>& angle_vec,
  * 
  * @param[in] angle             Angle as a vector of doubles
  * 
- * An exception is thrown if @p angle_type is neither HMS or DMS
+ * The @p angle parameter should contain hours and minutes as whole numbers,
+ * as they will be be cast to integers. The seconds parameter is assumed to 
+ * be at index [2], or split across index [2] and [3] if "angle.size() == 4".
+ * This allows dividing the seconds across two indices.
  *************************************************************************/
 void CEAngle::SetAngle_HmsVect(const std::vector<double>& angle)
 {
@@ -508,15 +511,15 @@ void CEAngle::SetAngle_HmsVect(const std::vector<double>& angle)
             // Hours out of bounds
             case 1:
                 msg += "Hour value \'" + std::to_string(angle[0]) + "\' not in range 0-23";
-                throw CEException::invalid_value("CEAngle::SetAngle", msg);
+                throw CEException::invalid_value("CEAngle::SetAngle_HmsVect", msg);
             // Minutes out of bounds
             case 2:
                 msg += "Minutes value \'" + std::to_string(angle[1]) + "\' not in range 0-59";
-                throw CEException::invalid_value("CEAngle::SetAngle", msg);
+                throw CEException::invalid_value("CEAngle::SetAngle_HmsVect", msg);
             // Seconds out of bounds
             case 3:
                 msg += "Seconds value \'" + std::to_string(sec) + "\' not in range 0-59.999...";
-                throw CEException::invalid_value("CEAngle::SetAngle", msg);
+                throw CEException::invalid_value("CEAngle::SetAngle_HmsVect", msg);
         }
     }
 
@@ -527,11 +530,14 @@ void CEAngle::SetAngle_HmsVect(const std::vector<double>& angle)
 
 
 /**********************************************************************//**
- * Set the angle from a vector of doubles
+ * Set the angle from a vector of doubles of the form {degrees, arcmin, arcsec}
  * 
  * @param[in] angle             Angle as a vector of doubles
  * 
- * An exception is thrown if @p angle_type is neither HMS or DMS
+ * The @p angle parameter should contain degrees and arcmins as whole numbers,
+ * as they will be be cast to integers. The arcsecs parameter is assumed to 
+ * be at index [2], or split across index [2] and [3] if "angle.size() == 4".
+ * This allows dividing the seconds across two indices.
  *************************************************************************/
 void CEAngle::SetAngle_DmsVect(const std::vector<double>& angle)
 {
@@ -552,15 +558,15 @@ void CEAngle::SetAngle_DmsVect(const std::vector<double>& angle)
             // Hours out of bounds
             case 1:
                 msg += "Degree value \'" + std::to_string(angle[0]) + "\' not in range 0-359";
-                throw CEException::invalid_value("CECoordinates::DMSToAngle", msg);
+                throw CEException::invalid_value("CEAngle::SetAngle_DmsVect", msg);
             // Minutes out of bounds
             case 2:
                 msg += "Arcmin value \'" + std::to_string(angle[1]) + "\' not in range 0-59";
-                throw CEException::invalid_value("CECoordinates::DMSToAngle", msg);
+                throw CEException::invalid_value("CEAngle::SetAngle_DmsVect", msg);
             // Seconds out of bounds
             case 3:
                 msg += "Arcsec value \'" + std::to_string(sec) + "\' not in range 0-59.999...";
-                throw CEException::invalid_value("CECoordinates::DMSToAngle", msg);
+                throw CEException::invalid_value("CEAngle::SetAngle_DmsVect", msg);
         }
     }
 

--- a/cppephem/src/CEAngle.cpp
+++ b/cppephem/src/CEAngle.cpp
@@ -317,7 +317,7 @@ std::vector<double> CEAngle::DmsVect(void) const
  *************************************************************************/
 CEAngle CEAngle::Deg(const double& angle)
 {
-    return angle * DD2R;
+    return CEAngle(angle * DD2R);
 }
 
 
@@ -340,7 +340,7 @@ double CEAngle::Deg(void) const
  *************************************************************************/
 CEAngle CEAngle::Rad(const double& angle)
 {
-    return angle;
+    return CEAngle(angle);
 }
 
 
@@ -372,11 +372,11 @@ void CEAngle::SetAngle(const double&      angle,
 {
     // Set from degree angle
     if (angle_type == CEAngleType::DEGREES) {
-        angle_ = iauAnp(angle * DD2R);
+        angle_ = angle * DD2R;
     }
     // Set from radians angle
     else if (angle_type == CEAngleType::RADIANS) {
-        angle_ = iauAnp(angle);
+        angle_ = angle;
     }
     // Otherwise throw an exception
     else {

--- a/cppephem/src/CEAngle.cpp
+++ b/cppephem/src/CEAngle.cpp
@@ -28,6 +28,7 @@
  format they prefer
  */
 
+#include <algorithm>
 
 #include "CEAngle.h"
 #include "CEException.h"
@@ -82,6 +83,21 @@ CEAngle& CEAngle::operator=(const CEAngle& other)
 
 
 /**********************************************************************//**
+ * Copy assignment operator from a double
+ * 
+ * @param[in] other         double angle (radians)
+ * @return CEAngle object constructed from @p other
+ *************************************************************************/
+CEAngle& CEAngle::operator=(const double& other)
+{
+    free_members();
+    init_members();
+    SetAngle(other, CEAngleType::RADIANS);
+    return *this;
+}
+
+
+/**********************************************************************//**
  * Return a double object representing the angle in radians
  *************************************************************************/
 CEAngle::operator double()
@@ -100,10 +116,11 @@ CEAngle::operator double() const
 
 
 /**********************************************************************//**
- * Return CEAngle constructed from a string representing hours, minutes, seconds
+ * Return angle constructed from a string representing hours, minutes, seconds
  * 
- * @param[in] angle             Angle representing hours, minutes, seconds
+ * @param[in] angle_str         Angle representing hours, minutes, seconds
  * @param[in] delim             Delimiter, by default all methods will be tested
+ * @return Angle in radians
  * 
  * The following values for @p delim are special cases:
  *      * 0 (int) = tests all following possible values for delimiter
@@ -111,32 +128,58 @@ CEAngle::operator double() const
  *      * ' ' = 'HH MM SS'
  *      * <any char> = The DD, MM, SS is separated by a user defined char
  *************************************************************************/
-CEAngle CEAngle::Hms(const std::string& angle, const char& delim=0)
+double CEAngle::Hms(const std::string& angle_str, 
+                     const char&        delim)
 {
     CEAngle angle;
-    angle.SetAngle(angle, CEAngleType::HMS, delim);
-    return angle;
+    angle.SetAngle(angle_str, CEAngleType::HMS, delim);
+    return angle.Rad();
 }
 
 
 /**********************************************************************//**
- * Return CEAngle constructed from a string representing hours, minutes, seconds
+ * Return angle constructed from a string representing hours, minutes, seconds
  * 
- * @param[in] angle             Angle representing hours, minutes, seconds
- * @return CEAngle object
+ * @param[in] angle_vec         Angle representing hours, minutes, seconds
+ * @return Angle in radians
+ * 
+ * The input @p angle is represented in the following manner
+ *      [0] = hours
+ *      [1] = minutes
+ *      [2] = seconds
+ *      [3] = (optional) seconds fraction
+ * The index [3] is optional if index [2] contains the whole seconds portion
  *************************************************************************/
-CEAngle CEAngle::Hms(const std::vector<double>& angle)
+double CEAngle::Hms(const std::vector<double>& angle_vec)
 {
     CEAngle angle;
-    angle.SetAngle(angle, CEAngleType::HMS);
-    return angle;
+    angle.SetAngle(angle_vec, CEAngleType::HMS);
+    return angle.Rad();
 }
 
 
-std::string CEAngle::Hms(const char& delim)
+/**********************************************************************//**
+ * Return string representing the angle in HH:MM:SS
+ * 
+ * @param[in] delim             Delimiter to use in output string
+ * @return Angle formatted as a string HH:MM:SS
+ *************************************************************************/
+std::string CEAngle::HmsStr(const char& delim) const
 {
     // Get the angle as a vector
+    std::vector<double> hms_d = HmsVect();
+    
+    // Make sure there are only three values
+    if (hms_d.size() == 4) {
+        hms_d[2] += hms_d[3];
+    }
 
+    // Assemble the string using teh specified delimiter
+    std::string ret = std::to_string(int(hms_d[0])) + delim +
+                      std::to_string(int(hms_d[1])) + delim +
+                      std::to_string(hms_d[2]);
+    
+    return ret;
 }
 
 
@@ -175,9 +218,9 @@ std::vector<double> CEAngle::HmsVect(void) const
 
 
 /**********************************************************************//**
- * Return CEAngle constructed from a string representing degrees, minutes, seconds
+ * Return double constructed from a string representing degrees, minutes, seconds
  * 
- * @param[in] angle             Angle representing degrees, arcmins, arcsecs
+ * @param[in] angle_str         Angle representing degrees, arcmins, arcsecs
  * @param[in] delim             Delimiter, by default all methods will be tested
  * 
  * The following values for @p delim are special cases:
@@ -186,25 +229,58 @@ std::vector<double> CEAngle::HmsVect(void) const
  *      * ' ' = 'DD MM SS'
  *      * <any char> = The DD, MM, SS is separated by a user defined char
  *************************************************************************/
-CEAngle CEAngle::Dms(const std::string& angle, const char& delim=0)
+double CEAngle::Dms(const std::string& angle_str, 
+                    const char&        delim)
 {
     CEAngle angle;
-    angle.SetAngle(angle, CEAngleType::DMS, delim);
-    return angle;
+    angle.SetAngle(angle_str, CEAngleType::DMS, delim);
+    return angle.Rad();
 }
 
 
 /**********************************************************************//**
- * Return CEAngle constructed from a string representing degrees, minutes, seconds
+ * Return angle constructed from a string representing degrees, minutes, seconds
  * 
- * @param[in] angle             Angle representing degrees, arcmins, arcsecs
- * @return CEAngle object
+ * @param[in] angle_vec         Angle representing degrees, minutes, seconds
+ * @return Angle in radians
+ * 
+ * The input @p angle is represented in the following manner
+ *      [0] = degrees
+ *      [1] = minutes
+ *      [2] = seconds
+ *      [3] = (optional) seconds fraction
+ * The index [3] is optional if index [2] contains the whole seconds portion
  *************************************************************************/
-CEAngle CEAngle::Dms(const std::vector<double>& angle)
+double CEAngle::Dms(const std::vector<double>& angle_vec)
 {
     CEAngle angle;
-    angle.SetAngle(angle, CEAngleType::DMS);
-    return angle;
+    angle.SetAngle(angle_vec, CEAngleType::DMS);
+    return angle.Rad();
+}
+
+
+/**********************************************************************//**
+ * Return string representing the angle in DD:MM:SS
+ * 
+ * @param[in] delim             Delimiter to use in output string
+ * @return Angle formatted as a string DD:MM:SS
+ *************************************************************************/
+std::string CEAngle::DmsStr(const char& delim) const
+{
+    // Get the angle as a vector
+    std::vector<double> dms_d = DmsVect();
+    
+    // Make sure there are only three values
+    if (dms_d.size() == 4) {
+        dms_d[2] += dms_d[3];
+    }
+
+    // Assemble the string using teh specified delimiter
+    std::string ret = std::to_string(int(dms_d[0])) + delim +
+                      std::to_string(int(dms_d[1])) + delim +
+                      std::to_string(dms_d[2]);
+    
+    return ret;
 }
 
 
@@ -240,14 +316,14 @@ std::vector<double> CEAngle::DmsVect(void) const
 
 
 /**********************************************************************//**
- * Return CEAngle constructed from a degree angle
+ * Return angle (radians) constructed from a degree angle
  * 
  * @param[in] angle             Angle in degrees
  * @return CEAngle object
  *************************************************************************/
-CEAngle CEAngle::Deg(const double& angle)
+double CEAngle::Deg(const double& angle)
 {
-    return CEAngle(angle*DD2R);
+    return angle * DD2R;
 }
 
 
@@ -256,21 +332,21 @@ CEAngle CEAngle::Deg(const double& angle)
  * 
  * @return Angle in degrees as a double
  *************************************************************************/
-double CEAngle::Deg(void)
+double CEAngle::Deg(void) const
 {
     return angle_ * DR2D;
 }
 
 
 /**********************************************************************//**
- * Return CEAngle constructed from a radians angle
+ * Return angle constructed from a radians angle
  * 
  * @param[in] angle             Angle in radians
- * @return CEAngle object
+ * @return Angle constructed from a 'radians' object
  *************************************************************************/
-CEAngle CEAngle::Rad(const double& angle)
+double CEAngle::Rad(const double& angle)
 {
-    return CEAngle(angle);
+    return angle;
 }
 
 
@@ -279,7 +355,7 @@ CEAngle CEAngle::Rad(const double& angle)
  * 
  * @return Angle in radians as a double
  *************************************************************************/
-double CEAngle::Rad(void)
+double CEAngle::Rad(void) const
 {
     return angle_;
 }
@@ -346,7 +422,7 @@ void CEAngle::SetAngle(const std::string& angle,
             if (angle_str.size() < 3) {
                 throw CEException::invalid_value(
                     "CEAngle::SetAngle(const string&, const CEAngleType&, const char&)",
-                    "[ERROR] Could not find specified delimiter: " + std::string(delim));
+                    "[ERROR] Could not find specified delimiter: " + std::string(&delim));
             }
         } 
         

--- a/cppephem/src/CEAngle.cpp
+++ b/cppephem/src/CEAngle.cpp
@@ -465,30 +465,14 @@ void CEAngle::SetAngle(const char*        angle_str,
 
             // Create vector of delimiters to be tried
             std::vector<char> delim_list = {':', ' '};
-            bool success = false;
 
             // Loop through the list of delimiters
             for (char d : delim_list) {
-
-                try {
+                // Check if the delimiter is in the string
+                if (std::string(angle_str).find(d) != std::string::npos) {
                     // Try to set the angle
                     SetAngle(angle_str, angle_type, d);
-                    success = true;
-                    break;
-                } catch (CEException::invalid_delimiter& e) {
-                    // Failed, but may need to try the next one
                 }
-            }
-
-            // Make sure setting the angle was a success
-            if (!success) {
-                // Throw a delimiter error
-                std::string msg = "Unable to parse angle string with default delimiters: ";
-                for (char d : delim_list) msg += std::string(1, d) + ", ";
-
-                throw CEException::invalid_delimiter(
-                    "CEAngle::SetAngle(const string&, const CEAngleType&, const char&)",
-                    msg);
             }
         }
     }

--- a/cppephem/src/CEBody.cpp
+++ b/cppephem/src/CEBody.cpp
@@ -46,11 +46,11 @@ CEBody::CEBody() : CECoordinates()
  * @param[in] angle_type   Angle type (either DEGREES or RADIANS)
  * @param[in] coord_type   Coordinate type (see CECoordinateType)
  *************************************************************************/
-CEBody::CEBody(const std::string& name,
-               const double& xcoord, const double& ycoord,
-               const CECoordinateType& coord_type,
-               const CEAngleType& angle_type) :
-    CECoordinates(xcoord, ycoord, coord_type, angle_type)
+CEBody::CEBody(const std::string&      name,
+               const CEAngle&          xcoord, 
+               const CEAngle&          ycoord,
+               const CECoordinateType& coord_type) :
+    CECoordinates(xcoord, ycoord, coord_type)
 {
     init_members();
     SetName(name);
@@ -61,7 +61,8 @@ CEBody::CEBody(const std::string& name,
  * @param[in] other         CEBody object to copy from
  * @param[in] name          New object name
  *************************************************************************/
-CEBody::CEBody(const CEBody &other, const std::string& name) :
+CEBody::CEBody(const CEBody&      other, 
+               const std::string& name) :
     CECoordinates(other)
 {
     init_members();
@@ -75,7 +76,8 @@ CEBody::CEBody(const CEBody &other, const std::string& name) :
  * Copy constructor from a single set of coordinates
  * @param[in] coords       coordinates object
  *************************************************************************/
-CEBody::CEBody(const CECoordinates &coords, const std::string& name) :
+CEBody::CEBody(const CECoordinates& coords, 
+               const std::string&   name) :
     CECoordinates(coords)
 {
     init_members();

--- a/cppephem/src/CECoordinates.cpp
+++ b/cppephem/src/CECoordinates.cpp
@@ -79,7 +79,7 @@ CECoordinates::CECoordinates(const std::vector<double>& xcoord,
     } else {
         x = CEAngle::Hms(xcoord);
     }
-    CEAngle y = CECoordinates::DMSToAngle(ycoord, CEAngleType::RADIANS);
+    CEAngle y = CEAngle::Dms(ycoord);
     CECoordinates::SetCoordinates(x, y, coord_type);
 }
 
@@ -1240,8 +1240,8 @@ CEAngle CECoordinates::AngularSeparation(const CEAngle& xcoord_first,
                                          const CEAngle& ycoord_second)
 {
     // Call the 'iauSeps' SOFA algorithm
-    CEAngle angsep = iauSeps(xcoord_first, ycoord_first,
-                             xcoord_second, ycoord_second) ;
+    CEAngle angsep(iauSeps(xcoord_first, ycoord_first,
+                           xcoord_second, ycoord_second)) ;
     
     return angsep ;
 }

--- a/cppephem/src/CECoordinates.cpp
+++ b/cppephem/src/CECoordinates.cpp
@@ -50,13 +50,12 @@ CECoordinates::CECoordinates()
  * @param[in] coord_type Coordinate type (see CECoordinateType)
  * @param[in] angle_type Angle type (either DEGREES or RADIANS)
  *************************************************************************/
-CECoordinates::CECoordinates(const double& xcoord, 
-                             const double& ycoord,
-                             const CECoordinateType& coord_type,
-                             const CEAngleType& angle_type)
+CECoordinates::CECoordinates(const CEAngle& xcoord, 
+                             const CEAngle& ycoord,
+                             const CECoordinateType& coord_type)
 {
     init_members();
-    CECoordinates::SetCoordinates(xcoord, ycoord, coord_type, angle_type);
+    CECoordinates::SetCoordinates(xcoord, ycoord, coord_type);
 }
 
 
@@ -73,9 +72,15 @@ CECoordinates::CECoordinates(const std::vector<double>& xcoord,
                              const CECoordinateType& coord_type)
 {
     init_members();
-    double x = CECoordinates::HMSToAngle(xcoord, CEAngleType::RADIANS);
-    double y = CECoordinates::DMSToAngle(ycoord, CEAngleType::RADIANS);
-    CECoordinates::SetCoordinates(x, y, coord_type, CEAngleType::RADIANS);
+    CEAngle x;
+    if ((coord_type == CECoordinateType::GALACTIC) || 
+        (coord_type == CECoordinateType::OBSERVED)) {
+        x = CEAngle::Dms(xcoord);
+    } else {
+        x = CEAngle::Hms(xcoord);
+    }
+    CEAngle y = CECoordinates::DMSToAngle(ycoord, CEAngleType::RADIANS);
+    CECoordinates::SetCoordinates(x, y, coord_type);
 }
 
 
@@ -1414,8 +1419,7 @@ CECoordinates CECoordinates::ConvertToCIRS(double jd,
     
     return CECoordinates(xcoord_new, 
                          ycoord_new,
-                         CECoordinateType::CIRS,
-                         CEAngleType::RADIANS) ;
+                         CECoordinateType::CIRS) ;
 }
 
 /**********************************************************************//**
@@ -1470,8 +1474,7 @@ CECoordinates CECoordinates::ConvertToICRS(double jd,
     }
     
     return CECoordinates(xcoord_new, ycoord_new,
-                         CECoordinateType::ICRS,
-                         CEAngleType::RADIANS) ;
+                         CECoordinateType::ICRS) ;
 }
 
 /**********************************************************************//**
@@ -1525,8 +1528,7 @@ CECoordinates CECoordinates::ConvertToGalactic(double jd,
         std::cerr << "[ERROR] Unknown coordinate type!\n" ;
     }
     
-    return CECoordinates(xcoord_new, ycoord_new, CECoordinateType::GALACTIC,
-                         CEAngleType::RADIANS) ;
+    return CECoordinates(xcoord_new, ycoord_new, CECoordinateType::GALACTIC) ;
 }
 
 /**********************************************************************//**
@@ -1609,8 +1611,7 @@ CECoordinates CECoordinates::ConvertToObserved(double jd,
                                          msg);
     }
  
-    return CECoordinates(xcoord_new, ycoord_new, CECoordinateType::OBSERVED,
-                         CEAngleType::RADIANS) ;
+    return CECoordinates(xcoord_new, ycoord_new, CECoordinateType::OBSERVED) ;
 }
 
 /**********************************************************************//**
@@ -1626,26 +1627,9 @@ CECoordinates CECoordinates::ConvertToObserved(double jd,
 std::vector<double> CECoordinates::GetDMS(const double& angle,
                                           const CEAngleType& angle_type)
 {
-    // Convert to degrees if passed radians
-    double ang = angle;
-    if (angle_type == CEAngleType::DEGREES) 
-        ang *= DD2R ;
-
-    // Variables for holding the results
-    char sign;
-    std::vector<int> DMS_i(4, 0.0);
-
-    // Run the appropriate SOFA value
-    iauA2af(9, ang, &sign, &DMS_i[0]);
-
-    // Fill the values into a double vector
-    std::vector<double> DMS_d(4, 0.0);
-    DMS_d[0] = DMS_i[0] * (sign == '-' ? -1.0 : 1.0);
-    DMS_d[1] = DMS_i[1];
-    DMS_d[2] = DMS_i[2];
-    DMS_d[3] = DMS_i[3] * 1.0e-9;
-
-    return DMS_d ;
+    CEAngle ang;
+    ang.SetAngle(angle, angle_type);
+    return ang.DmsVect() ;
 }
 
 /**********************************************************************//**
@@ -1663,28 +1647,9 @@ std::vector<double> CECoordinates::GetHMS(const double& angle,
                                           const CEAngleType& angle_type)
 {
     // Convert to degrees if passed radians
-    double ang(angle);
-
-    if (angle_type == CEAngleType::DEGREES) 
-        ang *= DD2R ;
-    
-    // Stores the resulting values
-    std::vector<int> HMS_i(4);
-    // Stores the sign
-    char pm;
-    iauA2tf(9, ang, &pm, &HMS_i[0]);
-    
-    // Convert the values into doubles
-    std::vector<double> HMS_d(HMS_i.size());
-    // Scale the fraction to be a true fraction
-    HMS_d[0] = double(HMS_i[0]);
-    HMS_d[1] = double(HMS_i[1]);
-    HMS_d[2] = double(HMS_i[2]);
-    HMS_d[3] = double(HMS_i[3])/1.0e9;
-    // Multiply the degree by a negative
-    if (pm == '-') HMS_d[0] *= -1;
-
-    return HMS_d;
+    CEAngle ang;
+    ang.SetAngle(angle, angle_type);
+    return ang.HmsVect();
 }
 
 
@@ -1704,37 +1669,13 @@ std::vector<double> CECoordinates::GetHMS(const double& angle,
 double CECoordinates::HMSToAngle(const std::vector<double>& angle,
                                  const CEAngleType& return_type)
 {
-    // Get the angle sign
-    char pm = (angle[0] >= 0.0) ? '+' : '-';
+    CEAngle ret_angle = CEAngle::Hms(angle);
 
-    // Do the conversion
-    double ang(0.0);
-    double sec = (angle.size() == 4) ? angle[2]+angle[3] : angle[2];
-    int err = iauTf2a(pm, std::abs(angle[0]), int(angle[1]), sec, &ang);
-
-    // Handle the error
-    if (err != 0) {
-        std::string msg = "[ERROR] ";
-        switch(err) {
-            // Hours out of bounds
-            case 1:
-                msg += "Hour value \'" + std::to_string(angle[0]) + "\' not in range 0-23";
-                throw CEException::invalid_value("CECoordinates::HMSToAngle", msg);
-            // Minutes out of bounds
-            case 2:
-                msg += "Minutes value \'" + std::to_string(angle[1]) + "\' not in range 0-59";
-                throw CEException::invalid_value("CECoordinates::HMSToAngle", msg);
-            // Seconds out of bounds
-            case 3:
-                msg += "Seconds value \'" + std::to_string(sec) + "\' not in range 0-59.999...";
-                throw CEException::invalid_value("CECoordinates::HMSToAngle", msg);
-        }
+    if (return_type == CEAngleType::DEGREES) {
+        return ret_angle.Deg();
+    } else {
+        return ret_angle.Rad();
     }
-
-    // Convert to appropriate return_type
-    if (return_type == CEAngleType::DEGREES) ang *= DR2D;
-
-    return ang;
 }
 
 
@@ -1754,19 +1695,13 @@ double CECoordinates::HMSToAngle(const std::vector<double>& angle,
 double CECoordinates::DMSToAngle(const std::vector<double>& angle,
                                  const CEAngleType& return_type)
 {
-    // Convert the values to an angle in degrees
-    double ret_angle;
-    char   sign = (angle[0] < 0.0) ? '-' : '+';
-    double sec  = (angle.size() == 3) ? angle[2] : angle[2]+angle[3];
-
-    // Pass the values to the appropriate SOFA algorithm
-    iauAf2a(sign, int(angle[0]), int(angle[1]), sec, &ret_angle);
+    CEAngle ret_angle = CEAngle::Dms(angle);
     
     if (return_type == CEAngleType::DEGREES) {
-        ret_angle *= DR2D;
+        return ret_angle.Deg();
+    } else {
+        return ret_angle.Rad();
     }
-
-    return ret_angle;
 }
 
 
@@ -1777,18 +1712,12 @@ double CECoordinates::DMSToAngle(const std::vector<double>& angle,
  * @param[in] coord_type       Coordinate type (see ::CECoordinateType)
  * @param[in] angle_type       Specifies whether xcoord & ycoord are in RADIANS or DEGREES (see ::CEAngleType)
  *************************************************************************/
-void CECoordinates::SetCoordinates(const double& xcoord, 
-                                   const double& ycoord,
-                                   const CECoordinateType& coord_type,
-                                   const CEAngleType& angle_type)
+void CECoordinates::SetCoordinates(const CEAngle& xcoord, 
+                                   const CEAngle& ycoord,
+                                   const CECoordinateType& coord_type)
 {
-    if (angle_type == CEAngleType::RADIANS) {
-        xcoord_ = xcoord ;
-        ycoord_ = ycoord ;
-    } else {
-        xcoord_ = xcoord * DD2R ;
-        ycoord_ = ycoord * DD2R ;
-    }
+    xcoord_     = xcoord ;
+    ycoord_     = ycoord ;
     coord_type_ = coord_type ;
 }
 

--- a/cppephem/src/CECoordinates.cpp
+++ b/cppephem/src/CECoordinates.cpp
@@ -1166,13 +1166,11 @@ CECoordinates CECoordinates::GetObservedCoords(const CEDate& date,
  * are in different coordinate systems, use "ConvertTo()" first.
  * 
  * @param[in] coords               Another set of coordinates
- * @param[in] return_angle_type    Specify whether to return angle as DEGREES or RADIANS
  * @return Angular separation between these coordinates and 'coords'
  *************************************************************************/
-double CECoordinates::AngularSeparation(const CECoordinates& coords,
-                                        const CEAngleType& return_angle_type) const
+CEAngle CECoordinates::AngularSeparation(const CECoordinates& coords) const
 {
-    return AngularSeparation(*this, coords, return_angle_type) ;
+    return AngularSeparation(*this, coords);
 }
 
 /**********************************************************************//**
@@ -1190,9 +1188,8 @@ double CECoordinates::AngularSeparation(const CECoordinates& coords,
  * y-coordinates are expected in the range [-pi, pi]. Because of this, OBSERVED
  * coordinates first convert the zenith angle to altitude
  *************************************************************************/
-double CECoordinates::AngularSeparation(const CECoordinates& coords1, 
-                                        const CECoordinates& coords2,
-                                        const CEAngleType& return_angle_type)
+CEAngle CECoordinates::AngularSeparation(const CECoordinates& coords1, 
+                                         const CECoordinates& coords2)
 {
     // Make sure the coordinates are in the same frame
     if (coords1.GetCoordSystem() != coords2.GetCoordSystem()) {
@@ -1209,13 +1206,8 @@ double CECoordinates::AngularSeparation(const CECoordinates& coords1,
     }
 
     // Convert the second coordinates to be the same type as the first set of coordinates
-    double angsep = AngularSeparation(coords1.XCoordinate_Rad(), y1,
-                                      coords2.XCoordinate_Rad(), y2,
-                                      CEAngleType::RADIANS) ;
-    // Convert radians to degrees if a return type of degrees is requested
-    if (return_angle_type == CEAngleType::DEGREES) {
-        angsep *= DR2D ;
-    }
+    CEAngle angsep = AngularSeparation(coords1.XCoord(), y1,
+                                       coords2.XCoord(), y2) ;
     
     return angsep ;
 }
@@ -1242,30 +1234,15 @@ double CECoordinates::AngularSeparation(const CECoordinates& coords1,
  *  - GALACTIC: G.Lon, G.Lat
  *  - OBSERVED: Az, Alt (by default the y-coordinate is zenith)
  *************************************************************************/
-double CECoordinates::AngularSeparation(double xcoord_first, 
-                                        double ycoord_first,
-                                        double xcoord_second, 
-                                        double ycoord_second,
-                                        const  CEAngleType& angle_type)
+CEAngle CECoordinates::AngularSeparation(const CEAngle& xcoord_first, 
+                                         const CEAngle& ycoord_first,
+                                         const CEAngle& xcoord_second, 
+                                         const CEAngle& ycoord_second)
 {
-    // Note that the 'iauSeps' algorithm expects angles in radians,
-    // so we need to convert if angles were passed in degrees
-    if (angle_type == CEAngleType::DEGREES) {
-        // Convert the coordinates to radians
-        xcoord_first *= DD2R ;
-        ycoord_first *= DD2R ;
-        xcoord_second *= DD2R ;
-        ycoord_second *= DD2R ;
-    }
-    
     // Call the 'iauSeps' SOFA algorithm
-    double angsep = iauSeps(xcoord_first, ycoord_first,
-                            xcoord_second, ycoord_second) ;
+    CEAngle angsep = iauSeps(xcoord_first, ycoord_first,
+                             xcoord_second, ycoord_second) ;
     
-    // Convert back to degrees if requested
-    if (angle_type == CEAngleType::DEGREES) {
-        angsep *= DR2D ;
-    }
     return angsep ;
 }
 
@@ -1792,7 +1769,7 @@ bool operator==(const CECoordinates& lhs, const CECoordinates& rhs)
     // Check that the x-coordinate and the y-coordinate are the same
     else {
         // Check how far appart the coordinates are from each other
-        double angsep(CECoordinates::AngularSeparation(lhs, rhs, CEAngleType::RADIANS));
+        CEAngle angsep = CECoordinates::AngularSeparation(lhs, rhs);
         // Currently require separation < 0.03 arcsec
         double marcsec_rad = 4.848e-6;
         if (angsep > 3.0*marcsec_rad) {

--- a/cppephem/src/CEException.cpp
+++ b/cppephem/src/CEException.cpp
@@ -107,6 +107,17 @@ CEException::invalid_value::invalid_value(const std::string& origin,
 
 
 /**********************************************************************//**
+ * Generate an exception of type "invalid_delimiter"
+ *  @param[in] origin       Method that threw the error
+ *  @param[in] message      Diagnostic message
+ *************************************************************************/
+CEException::invalid_delimiter::invalid_delimiter(const std::string& origin,
+                                                  const std::string& message) :
+    CEExceptionHandler(origin, message, "Invalid Delimiter")
+{}
+
+
+/**********************************************************************//**
  * Generate an exception of type "corr_file_load_error"
  *  @param[in] origin       Method that threw the error
  *  @param[in] message      Diagnostic message

--- a/cppephem/src/CENamespace.cpp
+++ b/cppephem/src/CENamespace.cpp
@@ -21,6 +21,7 @@
 
 #include <cmath>
 #include <stdio.h>
+#include <sstream>
 #include "CENamespace.h"
 
 
@@ -205,23 +206,23 @@ double CppEphem::ttut1(const double& mjd)
  * @param[in] delim
  * @param[in] elems
  *************************************************************************/
-void CppEphem::StrOpt::split(const std::string &s, 
-                             char delim, 
-                             std::vector<std::string> &elems) 
+void CppEphem::StrOpt::split(const std::string&        s, 
+                             const char&               delim, 
+                             std::vector<std::string>& elems) 
 {
     std::stringstream ss(s);
     std::string item=std::string();
     while (std::getline(ss, item, delim)) {
         elems.push_back(item);
     }
-    return elems;
 }
 
 
 /**********************************************************************//**
  * Method for splitting a string based on some delimiter into a vector of strings
  *************************************************************************/
-std::vector<std::string> CppEphem::StrOpt::split(const std::string &s, char delim) 
+std::vector<std::string> CppEphem::StrOpt::split(const std::string& s, 
+                                                 const char&        delim) 
 {
     std::vector<std::string> elems;
     split(s, delim, elems);

--- a/cppephem/src/CENamespace.cpp
+++ b/cppephem/src/CENamespace.cpp
@@ -196,3 +196,34 @@ double CppEphem::ttut1(const double& mjd)
 {
     return corrections.ttut1(mjd);
 }
+
+
+/**********************************************************************//**
+ * Method for splitting a string based on some delimiter into a vector of strings
+ * 
+ * @param[in] s
+ * @param[in] delim
+ * @param[in] elems
+ *************************************************************************/
+void CppEphem::StrOpt::split(const std::string &s, 
+                             char delim, 
+                             std::vector<std::string> &elems) 
+{
+    std::stringstream ss(s);
+    std::string item=std::string();
+    while (std::getline(ss, item, delim)) {
+        elems.push_back(item);
+    }
+    return elems;
+}
+
+
+/**********************************************************************//**
+ * Method for splitting a string based on some delimiter into a vector of strings
+ *************************************************************************/
+std::vector<std::string> CppEphem::StrOpt::split(const std::string &s, char delim) 
+{
+    std::vector<std::string> elems;
+    split(s, delim, elems);
+    return elems;
+}

--- a/cppephem/src/CENamespace.cpp
+++ b/cppephem/src/CENamespace.cpp
@@ -20,6 +20,7 @@
  ***************************************************************************/
 
 #include <cmath>
+#include <iomanip>
 #include <stdio.h>
 #include <sstream>
 #include "CENamespace.h"
@@ -202,18 +203,18 @@ double CppEphem::ttut1(const double& mjd)
 /**********************************************************************//**
  * Method for splitting a string based on some delimiter into a vector of strings
  * 
- * @param[in] s
- * @param[in] delim
- * @param[in] elems
+ * @param[in]  s
+ * @param[in]  delim
+ * @param[out] elems
  *************************************************************************/
 void CppEphem::StrOpt::split(const std::string&        s, 
                              const char&               delim, 
-                             std::vector<std::string>& elems) 
+                             std::vector<std::string>* elems) 
 {
     std::stringstream ss(s);
     std::string item=std::string();
     while (std::getline(ss, item, delim)) {
-        elems.push_back(item);
+        elems->push_back(item);
     }
 }
 
@@ -225,6 +226,62 @@ std::vector<std::string> CppEphem::StrOpt::split(const std::string& s,
                                                  const char&        delim) 
 {
     std::vector<std::string> elems;
-    split(s, delim, elems);
+    split(s, delim, &elems);
     return elems;
+}
+
+
+/**********************************************************************//**
+ * Method for joining a vector of values based on some delimiter into a string
+ * 
+ * @param[in] values            Vector of values to be joined
+ * @param[in] delim             Delimiter to use between values
+ *************************************************************************/
+template <typename T>
+std::string CppEphem::StrOpt::join(const std::vector<T>& values,
+                                   const char&           delim)
+{
+    // Assemble the first value in the string
+    std::ostringstream ss;
+    if (values.size() > 0) {
+        ss << values[0];
+    }
+
+    // Now append the rest
+    for (int i=1; i<values.size(); i++) { 
+        ss << delim << values[i];
+    }
+
+    return ss.str();
+}
+// Define the typical use cases of CppEphem::StrOpt::join
+template std::string CppEphem::StrOpt::join<std::string>(
+    const std::vector<std::string>&, const char&);
+template std::string CppEphem::StrOpt::join<double>(
+    const std::vector<double>&, const char&);
+
+
+
+/**********************************************************************//**
+ * Method for splitting a string based on some delimiter into a vector of strings
+ *************************************************************************/
+std::string CppEphem::StrOpt::join_angle(const std::vector<double>& values,
+                                         const char&                delim)
+{
+    // Make sure there are only three values
+    double sec = values[2];
+    if (values.size() == 4) {
+        sec += values[3];
+    }
+
+    // Assemble the string using the specified delimiter
+    std::ostringstream ss;
+    ss << std::setfill('0') << std::setw(2) << int(values[0]);
+    ss << delim;
+    ss << std::setfill('0') << std::setw(2) << int(values[1]);
+    ss << delim;
+    ss << std::setfill('0') << std::setw(11) << std::fixed 
+       << std::setprecision(8) << sec;
+    
+    return std::string(ss.str());
 }

--- a/cppephem/src/CEPlanet.cpp
+++ b/cppephem/src/CEPlanet.cpp
@@ -155,11 +155,10 @@ CEPlanet::CEPlanet() :
  * @param[in] angle_type       Angle type for the coordinates passed
  *************************************************************************/
 CEPlanet::CEPlanet(const std::string&      name, 
-                   const double&           xcoord, 
-                   const double&           ycoord,
-                   const CECoordinateType& coord_type,
-                   const CEAngleType&      angle_type) :
-    CEBody(name, xcoord, ycoord, coord_type, angle_type)
+                   const CEAngle&          xcoord, 
+                   const CEAngle&          ycoord,
+                   const CECoordinateType& coord_type) :
+    CEBody(name, xcoord, ycoord, coord_type)
 {
     init_members();
 }
@@ -664,7 +663,7 @@ CECoordinates CEPlanet::ObservedCoords(const CEDate&     date,
     if (sofa_planet_id_ == 3.5) {
         coordsys = CECoordinateType::CIRS;
     }
-    CECoordinates coord(ra, dec, coordsys, CEAngleType::RADIANS);
+    CECoordinates coord(ra, dec, coordsys);
     
     return coord.ConvertTo(CECoordinateType::OBSERVED, observer, date);
 }
@@ -689,7 +688,11 @@ void CEPlanet::UpdateCoordinates(double new_jd) const
     std::vector<double> pos_delayed = PositionICRS_Obs(date);
 
     // Now compute the actual sky coordinates in ICRS
-    iauC2s(&pos_delayed[0], &xcoord_, &ycoord_);
+    double x;
+    double y;
+    iauC2s(&pos_delayed[0], &x, &y);
+    xcoord_ = x;
+    ycoord_ = y;
     
     // Make sure the x-coordinate is in the appropriate range
     xcoord_ = iauAnp(xcoord_);

--- a/cppephem/src/angsep.cpp
+++ b/cppephem/src/angsep.cpp
@@ -29,6 +29,7 @@
  *********************************************/
 
 CEExecOptions DefineOpts() ;
+CECoordinates ConstructCoords(const double& x, const double& y, bool isDeg);
 
 /*********************************************
  * MAIN
@@ -47,19 +48,21 @@ int main(int argc, char** argv)
     }
     
     // Find coordinates for the first object
-    double angsep = CECoordinates::AngularSeparation(opts.AsDouble("xcoord1"), opts.AsDouble("ycoord1"),
-                                                    opts.AsDouble("xcoord2"), opts.AsDouble("ycoord2"),
-                                                    in_ang_type) ;
+    CECoordinates coord1 = ConstructCoords(opts.AsDouble("xcoord1"),
+                                           opts.AsDouble("ycoord1"),
+                                           opts.AsBool("InputDegrees"));
+    CECoordinates coord2 = ConstructCoords(opts.AsDouble("xcoord2"),
+                                           opts.AsDouble("ycoord2"),
+                                           opts.AsBool("InputDegrees"));
+
+    CEAngle angsep = CECoordinates::AngularSeparation(coord1, coord2);
     
     // Figure out whether we need to convert the output angular separation
-    if (opts.AsBool("InputDegrees") && !opts.AsBool("OutputDegrees")) {
-        angsep *= DD2R;
-    } else if (!opts.AsBool("InputDegrees") && opts.AsBool("OutputDegrees")) {
-        angsep *= DR2D;
+    if (opts.AsBool("OutputDegrees")) {
+        std::cout << angsep.Deg() << std::endl;
+    } else {
+        std::cout << angsep.Rad() << std::endl;
     }
-    
-    // Print the result
-    std::cout << angsep << std::endl;
     
     return 0;
 }
@@ -97,4 +100,27 @@ CEExecOptions DefineOpts()
                         0.0);
     
     return opts;
+}
+
+
+/*****************************************//**
+ * Construct the coordinates object
+ * 
+ * @param[in] x         X-coordinate
+ * @param[in] y         Y-coordinate
+ * @param[in] isDeg     true if the coordinates are in degrees
+ * @return CECoordinates object
+ *********************************************/
+CECoordinates ConstructCoords(const double& x, const double& y, bool isDeg)
+{
+    CECoordinates coord;
+    if (isDeg) {
+        coord.SetCoordinates(CEAngle::Deg(x), CEAngle::Deg(y),
+                             CECoordinateType::ICRS);
+    } else {
+        coord.SetCoordinates(CEAngle::Rad(x), CEAngle::Rad(y),
+                             CECoordinateType::ICRS);
+    }
+
+    return coord;
 }

--- a/cppephem/src/cirs2icrs.cpp
+++ b/cppephem/src/cirs2icrs.cpp
@@ -86,8 +86,9 @@ int main (int argc, char** argv)
     if (opts.ParseCommandLine(argc, argv)) return 0 ;
     
     // Create a CECoordinates object
-    CECoordinates input(opts.AsDouble("ra"), opts.AsDouble("dec"),
-                        CECoordinateType::CIRS, CEAngleType::DEGREES) ;
+    CECoordinates input(CEAngle::Deg(opts.AsDouble("ra")), 
+                        CEAngle::Deg(opts.AsDouble("dec")),
+                        CECoordinateType::CIRS) ;
     
     // Get the coordinates as CIRS
     CECoordinates output = input.ConvertToICRS(opts.AsDouble("juliandate")) ;

--- a/cppephem/src/gal2icrs.cpp
+++ b/cppephem/src/gal2icrs.cpp
@@ -86,8 +86,9 @@ int main(int argc, char** argv) {
     if (opts.ParseCommandLine(argc, argv)) return 0 ;
         
     // Create a map to store the results
-    CECoordinates input(opts.AsDouble("glon"), opts.AsDouble("glat"),
-                        CECoordinateType::GALACTIC, CEAngleType::DEGREES) ;
+    CECoordinates input(CEAngle::Deg(opts.AsDouble("glon")), 
+                        CEAngle::Deg(opts.AsDouble("glat")),
+                        CECoordinateType::GALACTIC) ;
     
     // Convert the coordinates
     CECoordinates output = input.ConvertToICRS();

--- a/cppephem/src/icrs2cirs.cpp
+++ b/cppephem/src/icrs2cirs.cpp
@@ -86,8 +86,9 @@ int main (int argc, char** argv)
     if (opts.ParseCommandLine(argc, argv)) return 0 ;
     
     // Create a CECoordinates object
-    CECoordinates input(opts.AsDouble("ra"), opts.AsDouble("dec"),
-                        CECoordinateType::ICRS, CEAngleType::DEGREES) ;
+    CECoordinates input(CEAngle::Deg(opts.AsDouble("ra")), 
+                        CEAngle::Deg(opts.AsDouble("dec")),
+                        CECoordinateType::ICRS) ;
     
     // Get the coordinates as CIRS
     CECoordinates output = input.ConvertToCIRS(opts.AsDouble("juliandate")) ;

--- a/cppephem/src/icrs2gal.cpp
+++ b/cppephem/src/icrs2gal.cpp
@@ -81,8 +81,9 @@ int main(int argc, char** argv)
     if (opts.ParseCommandLine(argc, argv)) return 0 ;
         
     // Create a map to store the results
-    CECoordinates input(opts.AsDouble("ra"), opts.AsDouble("dec"),
-                        CECoordinateType::ICRS, CEAngleType::DEGREES) ;
+    CECoordinates input(CEAngle::Deg(opts.AsDouble("ra")),
+                        CEAngle::Deg(opts.AsDouble("dec")),
+                        CECoordinateType::ICRS) ;
     
     // Convert the coordinates
     CECoordinates output = input.ConvertToGalactic();

--- a/cppephem/src/icrs2obs.cpp
+++ b/cppephem/src/icrs2obs.cpp
@@ -93,8 +93,9 @@ int main(int argc, char** argv)
     if (opts.ParseCommandLine(argc, argv)) return 0;
     
     // Create the input and output coordinates
-    CECoordinates input(opts.AsDouble("ra"), opts.AsDouble("dec"),
-                        CECoordinateType::ICRS, CEAngleType::DEGREES);
+    CECoordinates input(CEAngle::Deg(opts.AsDouble("ra")), 
+                        CEAngle::Deg(opts.AsDouble("dec")),
+                        CECoordinateType::ICRS);
     
     // Define the date
     CEDate date(opts.AsDouble("juliandate"), CEDateType::JD);

--- a/cppephem/src/planetephem.cpp
+++ b/cppephem/src/planetephem.cpp
@@ -205,7 +205,7 @@ void PrintEphemeris(CEObservation& obs,
 
         // Get the observed coordinates
         obs_coords.SetCoordinates(obs.GetAzimuth_Rad(), obs.GetZenith_Rad(),
-                                  CECoordinateType::OBSERVED, CEAngleType::RADIANS);
+                                  CECoordinateType::OBSERVED);
         // Convert to RA,DEC
         appar_coords = obs_coords.ConvertToICRS(date->JD(),
                                                 observer->Longitude_Rad(),
@@ -219,8 +219,8 @@ void PrintEphemeris(CEObservation& obs,
                                                 date->ypolar(),
                                                 observer->Wavelength_um());
         // Update the coordiantes of the planet
-        ra  = CECoordinates::GetHMS( appar_coords.XCoordinate_Rad(), CEAngleType::RADIANS);
-        dec = CECoordinates::GetDMS( appar_coords.YCoordinate_Rad(), CEAngleType::RADIANS);
+        ra  = appar_coords.XCoord().HmsVect();
+        dec = appar_coords.YCoord().DmsVect();
         
         std::printf(" %11.2f  %08.1f  %2.0fh %2.0fm %4.1fs  %+3.0fd %2.0fm %4.1fs  %8.3f  %+7.3f\n",
                     double(*date), date->GetTime(observer->UTCOffset()),

--- a/cppephem/test/CMakeLists.txt
+++ b/cppephem/test/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include
                     )
 
 # Define the tests
+cppephem_test(test_CEAngle       test_CEAngle.cpp)
 cppephem_test(test_CEBody        test_CEBody.cpp)
 cppephem_test(test_CECoordinates test_CECoordinates.cpp)
 cppephem_test(test_CEDate        test_CEDate.cpp)

--- a/cppephem/test/test_CEAngle.cpp
+++ b/cppephem/test/test_CEAngle.cpp
@@ -87,6 +87,11 @@ bool test_CEAngle::test_construct(void)
     test4 = angle_test;
     test_double(test4, angle_test, __func__, __LINE__);
 
+    // Copy-assignment operator (CEAngle)
+    CEAngle test5;
+    test5 = base_;
+    test_double(test5, base_, __func__, __LINE__);
+
     return pass();
 }
 
@@ -133,6 +138,22 @@ bool test_CEAngle::test_setangle(void)
         test_ang.SetAngle(angle_hms_str1.c_str(), CEAngleType::HMS, ' ');
         test(false, __func__, __LINE__);
     } catch (CEException::invalid_delimiter& e) {
+        test(true, __func__, __LINE__);
+    }
+
+    // Try to set angle as a double, but with the wrong CEAngleType
+    try {
+        test_ang.SetAngle(123.456, CEAngleType::HMS);
+        test(false, __func__, __LINE__);
+    } catch (CEException::invalid_value& e) {
+        test(true, __func__, __LINE__);
+    }
+
+    // Try to set the angle from a vector<double> with wrong CEAngleType
+    try {
+        test_ang.SetAngle({123,45,6, 0.789}, CEAngleType::DEGREES);
+        test(false, __func__, __LINE__);
+    } catch (CEException::invalid_value& e) {
         test(true, __func__, __LINE__);
     }
 
@@ -194,6 +215,12 @@ bool test_CEAngle::test_retrieve(void)
 
     // DMS as vector<double>
     test_vect(test_ang.DmsVect(), {315, 15, 0, 0}, __func__, __LINE__);
+
+    // Can the angle be retrieved directly as a double?
+    test_double(test_ang, test_deg*DD2R, __func__, __LINE__);
+    const CEAngle test_ang2(test_ang);
+    // Test 'const' version
+    test_double(test_ang2, test_deg*DD2R, __func__, __LINE__);
 
     return pass();
 }

--- a/cppephem/test/test_CEAngle.cpp
+++ b/cppephem/test/test_CEAngle.cpp
@@ -192,7 +192,7 @@ bool test_CEAngle::test_retrieve(void)
     // Now test some of the other ways in which to get back the angle using
     // a particular format. For this, we will use 315.25 degrees
     double test_deg = 315.25;
-    CEAngle test_ang = test_deg * DD2R;
+    CEAngle test_ang(test_deg * DD2R);
 
     // Deg
     test_double(test_ang.Deg(), test_deg, __func__, __LINE__);
@@ -221,6 +221,54 @@ bool test_CEAngle::test_retrieve(void)
     const CEAngle test_ang2(test_ang);
     // Test 'const' version
     test_double(test_ang2, test_deg*DD2R, __func__, __LINE__);
+
+
+    // Test exceptions
+    CEAngle test_ang3;
+
+    // Incorrect hour
+    try {
+        test_ang3.SetAngle({25, 2, 3.3}, CEAngleType::HMS);
+        test(false, "HMS bad hours exception", __func__, __LINE__);
+    } catch (CEException::invalid_value& e) {
+        test(true, "HMS bad hours exception", __func__, __LINE__);
+    }
+    // Incorrect minutes
+    try {
+        test_ang3.SetAngle({1, -2, 3.3}, CEAngleType::HMS);
+        test(false, "HMS bad minutes exception", __func__, __LINE__);
+    } catch (CEException::invalid_value& e) {
+        test(true, "HMS bad minutes exception", __func__, __LINE__);
+    }
+    // Incorrect seconds
+    try {
+        test_ang3.SetAngle({1, 2, -3.3}, CEAngleType::HMS);
+        test(false, "HMS bad seconds exception", __func__, __LINE__);
+    } catch (CEException::invalid_value& e) {
+        test(true, "HMS bad seconds exception", __func__, __LINE__);
+    }
+
+    // Incorrect degrees
+    try {
+        test_ang3.SetAngle({370, 2, 3.3}, CEAngleType::DMS);
+        test(false, "DMS bad degrees exception", __func__, __LINE__);
+    } catch (CEException::invalid_value& e) {
+        test(true, "DMS bad degrees exception", __func__, __LINE__);
+    }
+    // Incorrect minutes
+    try {
+        test_ang3.SetAngle({1, -2, 3.3}, CEAngleType::DMS);
+        test(false, "DMS bad arcmins exception", __func__, __LINE__);
+    } catch (CEException::invalid_value& e) {
+        test(true, "DMS bad arcmins exception", __func__, __LINE__);
+    }
+    // Incorrect seconds
+    try {
+        test_ang3.SetAngle({1, 2, -3.3}, CEAngleType::DMS);
+        test(false, "DMS bad arcsecs exception", __func__, __LINE__);
+    } catch (CEException::invalid_value& e) {
+        test(true, "DMS bad arcsecs exception", __func__, __LINE__);
+    }
 
     return pass();
 }

--- a/cppephem/test/test_CEAngle.cpp
+++ b/cppephem/test/test_CEAngle.cpp
@@ -1,0 +1,208 @@
+/***************************************************************************
+ *  test_CEAngle.cpp: CppEphem                                             *
+ * ----------------------------------------------------------------------- *
+ *  Copyright © 2019 JCardenzana                                           *
+ * ----------------------------------------------------------------------- *
+ *                                                                         *
+ *  This program is free software: you can redistribute it and/or modify   *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation, either version 3 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  This program is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *  You should have received a copy of the GNU General Public License      *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <iostream>
+
+#include "test_CEAngle.h"
+#include "CEException.h"
+#include "CENamespace.h"
+
+
+/**********************************************************************//**
+ * Default constructor
+ *************************************************************************/
+test_CEAngle::test_CEAngle() :
+    CETestSuite()
+{
+    // Let's use 45 degrees for the tests, or PI/2
+    base_ = CEAngle(M_PI_2);
+}
+
+
+/**********************************************************************//**
+ * Destructor
+ *************************************************************************/
+test_CEAngle::~test_CEAngle()
+{}
+
+
+/**********************************************************************//**
+ * Run tests
+ * 
+ * @return whether or not all tests succeeded
+ *************************************************************************/
+bool test_CEAngle::runtests()
+{
+    std::cout << "\nTesting CEAngle:\n";
+
+    // Run each of the tests
+    test_construct();
+    test_setangle();
+    test_retrieve();
+
+    return pass();
+}
+
+
+/**********************************************************************//**
+ * Test the various constructor methods
+ * 
+ * @return whether or not all tests succeeded
+ *************************************************************************/
+bool test_CEAngle::test_construct(void)
+{
+    // Default constructor
+    CEAngle test1;
+    test_double(test1.Rad(), 0.0, __func__, __LINE__);
+
+    // Copy constructor (CEAngle)
+    CEAngle test2(base_);
+    test_double(test2.Rad(), base_.Rad(), __func__, __LINE__);
+
+    // Copy-assignment operator (CEAngle)
+    CEAngle test3 = base_;
+    test_double(test3.Rad(), base_.Rad(), __func__, __LINE__);
+
+    // Copy-assignment operator (double)
+    double angle_test = M_PI;
+    CEAngle test4 = angle_test;
+    test_double(test4.Rad(), angle_test, __func__, __LINE__);
+
+    return pass();
+}
+
+
+/**********************************************************************//**
+ * Test setting the angle from multiple methods representing 45 degrees
+ * 
+ * @return whether or not all tests succeeded
+ *************************************************************************/
+bool test_CEAngle::test_setangle(void)
+{
+    // Construct the test angle
+    CEAngle test_ang;
+    // Test radians
+    double angle_rad = M_PI_2;  // PI/2 radians or 90 degrees
+    test_ang.SetAngle(angle_rad, CEAngleType::RADIANS);
+    test_double(test_ang, angle_rad, __func__, __LINE__);
+
+    // Test degrees
+    double angle_deg = 180.0;
+    std::string angle_deg_str = "180.0";
+    test_ang.SetAngle(angle_deg, CEAngleType::DEGREES);
+    test_double(test_ang, M_PI, __func__, __LINE__);
+    test_ang.SetAngle(angle_deg_str.c_str(), CEAngleType::DEGREES);
+
+    // HMS values to be tested
+    std::string angle_hms_str1 = "3:0:0";
+    std::string angle_hms_str2 = "6 0 0";
+    std::string angle_hms_str3 = "9.0.0";
+    test_ang.SetAngle(angle_hms_str1.c_str(), CEAngleType::HMS);
+    test_double(test_ang, M_PI_2/2.0, __func__, __LINE__);
+    test_ang.SetAngle(angle_hms_str2.c_str(), CEAngleType::HMS);
+    test_double(test_ang, M_PI_2, __func__, __LINE__);
+    test_ang.SetAngle(angle_hms_str3.c_str(), CEAngleType::HMS, '.');
+    test_double(test_ang, 1.5 * M_PI_2, __func__, __LINE__);
+
+    // DMS values to be tested
+    std::string angle_dms_str1 = "45:0:0";
+    test_ang.SetAngle(angle_dms_str1.c_str(), CEAngleType::DMS);
+    test_double(test_ang, M_PI_2/2.0, __func__, __LINE__);
+
+    // Try to set the angle by passing the wrong delimiter
+    try {
+        test_ang.SetAngle(angle_hms_str1.c_str(), CEAngleType::HMS, ' ');
+        test(false, __func__, __LINE__);
+    } catch (CEException::invalid_delimiter& e) {
+        test(true, __func__, __LINE__);
+    }
+
+    return pass();
+}
+
+
+
+/**********************************************************************//**
+ * Test getting the angle from multiple methods
+ * 
+ * @return whether or not all tests succeeded
+ *************************************************************************/
+bool test_CEAngle::test_retrieve(void)
+{
+    double angle = M_PI;
+
+    // Test getting from...
+    // ... degrees
+    test_double(CEAngle::Deg(180), angle, __func__, __LINE__);
+    // ... radians
+    test_double(CEAngle::Rad(angle), angle, __func__, __LINE__);
+    // ... Hms (version 1)
+    test_double(CEAngle::Hms("12:00:00"), angle, __func__, __LINE__);
+    test_double(CEAngle::Hms("12 00 00"), angle, __func__, __LINE__);
+    test_double(CEAngle::Hms("12.00.00", '.'), angle, __func__, __LINE__);
+    // ... HMS (version 2)
+    test_double(CEAngle::Hms({12.0, 0.0, 0.0, 0.0}), angle, __func__, __LINE__);
+    // ... Dms (version 1)
+    test_double(CEAngle::Dms("180:00:00"), angle, __func__, __LINE__);
+    test_double(CEAngle::Dms("180 00 00"), angle, __func__, __LINE__);
+    test_double(CEAngle::Dms("180'00'00", '\''), angle, __func__, __LINE__);
+    // ... DMS (version 2)
+    test_double(CEAngle::Dms({180, 0, 0, 0.0}), angle, __func__, __LINE__);
+
+    // Now test some of the other ways in which to get back the angle using
+    // a particular format. For this, we will use 315.25 degrees
+    double test_deg = 315.25;
+    CEAngle test_ang = test_deg * DD2R;
+
+    // Deg
+    test_double(test_ang.Deg(), test_deg, __func__, __LINE__);
+
+    // Rad
+    test_double(test_ang.Rad(), test_deg*DD2R, __func__, __LINE__);
+    
+    // HMS as string
+    std::string hms_str = test_ang.HmsStr('\'');
+    hms_str = std::string(hms_str.begin(), hms_str.begin()+11);
+    test_string(hms_str, "21'01'00.00", __func__, __LINE__);
+    
+    // HMS as vector<double>
+    test_vect(test_ang.HmsVect(), {21, 1, 0, 0}, __func__, __LINE__);
+    
+    // DMS as string
+    std::string dms_str = test_ang.DmsStr('"');
+    dms_str = std::string(dms_str.begin(), dms_str.begin()+12);
+    test_string(dms_str, "315\"15\"00.00", __func__, __LINE__);
+
+    // DMS as vector<double>
+    test_vect(test_ang.DmsVect(), {315, 15, 0, 0}, __func__, __LINE__);
+
+    return pass();
+}
+
+
+/**********************************************************************//**
+ * Main method that actually runs the tests
+ *************************************************************************/
+int main(int argc, char** argv) 
+{
+    test_CEAngle tester;
+    return (!tester.runtests());
+}

--- a/cppephem/test/test_CEAngle.cpp
+++ b/cppephem/test/test_CEAngle.cpp
@@ -83,8 +83,9 @@ bool test_CEAngle::test_construct(void)
 
     // Copy-assignment operator (double)
     double angle_test = M_PI;
-    CEAngle test4 = angle_test;
-    test_double(test4.Rad(), angle_test, __func__, __LINE__);
+    CEAngle test4;
+    test4 = angle_test;
+    test_double(test4, angle_test, __func__, __LINE__);
 
     return pass();
 }

--- a/cppephem/test/test_CEAngle.h
+++ b/cppephem/test/test_CEAngle.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+ *  test_CEAngle.h: CppEphem                                               *
+ * ----------------------------------------------------------------------- *
+ *  Copyright © 2019 JCardenzana                                           *
+ * ----------------------------------------------------------------------- *
+ *                                                                         *
+ *  This program is free software: you can redistribute it and/or modify   *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation, either version 3 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  This program is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *  You should have received a copy of the GNU General Public License      *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef test_CEAngle_h
+#define test_CEAngle_h
+
+#include "CEAngle.h"
+#include "CETestSuite.h"
+
+class test_CEAngle : public CETestSuite {
+public:
+    test_CEAngle();
+    virtual ~test_CEAngle();
+
+    bool runtests();
+
+    /****** METHODS ******/
+
+    bool test_construct(void);
+    bool test_setangle(void);
+    bool test_retrieve(void);
+
+private:
+
+    CEAngle base_;
+
+};
+
+#endif /* test_CEAngle_h */

--- a/cppephem/test/test_CEBody.cpp
+++ b/cppephem/test/test_CEBody.cpp
@@ -30,9 +30,8 @@ test_CEBody::test_CEBody() :
     CETestSuite()
 {
     // Let's use the Crab Nebula
-    base_ = CEBody("Crab", 83.633, 22.0145, 
-                   CECoordinateType::ICRS, 
-                   CEAngleType::DEGREES);
+    base_ = CEBody("Crab", CEAngle::Deg(83.633), CEAngle::Deg(22.0145), 
+                   CECoordinateType::ICRS);
 }
 
 
@@ -89,8 +88,8 @@ bool test_CEBody::test_construct(void)
     
     // Basic constructor
     CEBody test4(test1.Name(),
-                 test1.XCoordinate_Rad(), test1.YCoordinate_Rad(),
-                 test1.GetCoordSystem(), CEAngleType::RADIANS);
+                 test1.XCoord(), test1.YCoord(),
+                 test1.GetCoordSystem());
     test_string(test4.Name(), test1.Name(), __func__, __LINE__);
     test(test4.GetCoordinates() == test1.GetCoordinates(), __func__, __LINE__);
 

--- a/cppephem/test/test_CECoordinates.cpp
+++ b/cppephem/test/test_CECoordinates.cpp
@@ -37,18 +37,17 @@ test_CECoordinates::test_CECoordinates() :
 
     // The following coordinates are derived from Astopy using the script:
     // cppephem/test/astropy_scripts/test_cecoordinates_setup.py
-    base_icrs_ = CECoordinates(83.633, 22.0145, 
-                               CECoordinateType::ICRS, 
-                               CEAngleType::DEGREES);
-    base_cirs_ = CECoordinates(83.63843844654943, 22.012942530431776,
-                               CECoordinateType::CIRS,
-                               CEAngleType::DEGREES);
-    base_gal_  = CECoordinates(184.55741630955762, -5.784421958594916,
-                               CECoordinateType::GALACTIC,
-                               CEAngleType::DEGREES);
-    base_obs_  = CECoordinates(35.598599384274294, 152.55068501449307,
-                               CECoordinateType::OBSERVED,
-                               CEAngleType::DEGREES);
+    base_icrs_ = CECoordinates(CEAngle::Deg(83.633), CEAngle::Deg(22.0145), 
+                               CECoordinateType::ICRS);
+    base_cirs_ = CECoordinates(CEAngle::Deg(83.63843844654943), 
+                               CEAngle::Deg(22.012942530431776),
+                               CECoordinateType::CIRS);
+    base_gal_  = CECoordinates(CEAngle::Deg(184.55741630955762), 
+                               CEAngle::Deg(-5.784421958594916),
+                               CECoordinateType::GALACTIC);
+    base_obs_  = CECoordinates(CEAngle::Deg(35.598599384274294), 
+                               CEAngle::Deg(152.55068501449307),
+                               CECoordinateType::OBSERVED);
 
     // Create the date object
     base_date_ = CEDate(CppEphem::julian_date_J2000(), CEDateType::JD);
@@ -106,28 +105,21 @@ bool test_CECoordinates::test_construct()
     // Test the default constructor
     CECoordinates test1;
     test_double(test1.XCoordinate_Rad(), 0.0, __func__, __LINE__);
+    test_double(test1.XCoord(), 0.0, __func__, __LINE__);
     test_double(test1.YCoordinate_Rad(), 0.0, __func__, __LINE__);
+    test_double(test1.YCoord(), 0.0, __func__, __LINE__);
     
-    // Test constructor from degrees
-    double testx(83.633);
-    double testy(22.0145);
-    CECoordinates test2(testx, testy, CECoordinateType::ICRS, CEAngleType::DEGREES);
-    test_double(test2.XCoordinate_Deg(), testx, __func__, __LINE__);
-    test_double(test2.YCoordinate_Deg(), testy, __func__, __LINE__);
-
-    // Test constructor from vectors of values
-    std::vector<double> testHMS = CECoordinates::GetHMS(testx,
-                                                        CEAngleType::DEGREES);
-    std::vector<double> testDMS = CECoordinates::GetDMS(testy,
-                                                        CEAngleType::DEGREES);
-    CECoordinates test3(testHMS, testDMS, CECoordinateType::ICRS);
-    test_double(test3.XCoordinate_Deg(), testx, __func__, __LINE__);
-    test_double(test3.YCoordinate_Deg(), testy, __func__, __LINE__);
+    // Test constructor from CEAngle objects
+    CEAngle testx = CEAngle::Deg(83.633);
+    CEAngle testy = CEAngle::Deg(22.0145);
+    CECoordinates test2(testx, testy, CECoordinateType::ICRS);
+    test_double(test2.XCoordinate_Rad(), testx, __func__, __LINE__);
+    test_double(test2.YCoordinate_Rad(), testy, __func__, __LINE__);
     
     // Test copy constructor
     CECoordinates test4(test2);
-    test_double(test4.XCoordinate_Deg(), testx, __func__, __LINE__);
-    test_double(test4.YCoordinate_Deg(), testy, __func__, __LINE__);
+    test_double(test4.XCoordinate_Rad(), testx, __func__, __LINE__);
+    test_double(test4.YCoordinate_Rad(), testy, __func__, __LINE__);
     test_int(int(test4.GetCoordSystem()), int(test2.GetCoordSystem()), __func__, __LINE__);
 
     // Test print of constructed coordinates
@@ -297,7 +289,8 @@ bool test_CECoordinates::test_Convert2Observed()
                                  base_date_, base_observer_, 
                                  CEAngleType::DEGREES,
                                  base_observer_.Wavelength_um());
-    testobs.SetCoordinates(az, zen, CECoordinateType::OBSERVED, CEAngleType::DEGREES);
+    testobs.SetCoordinates(CEAngle::Deg(az), CEAngle::Deg(zen), 
+                           CECoordinateType::OBSERVED);
     test_coords(testobs, base_obs_, __func__, __LINE__);
 
     // ICRS -> Observed
@@ -321,7 +314,8 @@ bool test_CECoordinates::test_Convert2Observed()
                                  base_date_, base_observer_, 
                                  CEAngleType::DEGREES,
                                  base_observer_.Wavelength_um());
-    testobs.SetCoordinates(az, zen, CECoordinateType::OBSERVED, CEAngleType::DEGREES);
+    testobs.SetCoordinates(CEAngle::Deg(az), CEAngle::Deg(zen), 
+                           CECoordinateType::OBSERVED);
     test_coords(testobs, base_obs_, __func__, __LINE__);
 
     // Galactic -> Observed
@@ -345,7 +339,8 @@ bool test_CECoordinates::test_Convert2Observed()
                                      base_date_, base_observer_, 
                                      CEAngleType::DEGREES,
                                      base_observer_.Wavelength_um());
-    testobs.SetCoordinates(az, zen, CECoordinateType::OBSERVED, CEAngleType::DEGREES);
+    testobs.SetCoordinates(CEAngle::Deg(az), CEAngle::Deg(zen), 
+                           CECoordinateType::OBSERVED);
     test_coords(testobs, base_obs_, __func__, __LINE__);
 
     return pass();
@@ -395,22 +390,21 @@ bool test_CECoordinates::test_HmsDms2Angle(void)
 bool test_CECoordinates::test_AngularSeparation(void)
 {
     // Establish the preliminary variables that will be used 
-    double test1_x(0.0);
-    double test1_y(-1.0);
-    double test2_x(0.0);
-    double test2_y(1.0);
-    CECoordinates test1(test1_x, test1_y, CECoordinateType::ICRS, CEAngleType::DEGREES);
-    CECoordinates test2(test2_x, test2_y, CECoordinateType::ICRS, CEAngleType::DEGREES);
+    CEAngle test1_x = CEAngle::Deg(0.0);
+    CEAngle test1_y = CEAngle::Deg(-1.0);
+    CEAngle test2_x = CEAngle::Deg(0.0);
+    CEAngle test2_y = CEAngle::Deg(1.0);
+    CECoordinates test1(test1_x, test1_y, CECoordinateType::ICRS);
+    CECoordinates test2(test2_x, test2_y, CECoordinateType::ICRS);
     
     // Test the default coordinate separation
-    double angsep = test1.AngularSeparation(test2, CEAngleType::DEGREES);
-    test_double(angsep, 2.0, __func__, __LINE__);
-    angsep = CECoordinates::AngularSeparation(test1, test2, CEAngleType::DEGREES);
-    test_double(angsep, 2.0, __func__, __LINE__);
+    CEAngle angsep = test1.AngularSeparation(test2);
+    test_double(angsep.Deg(), 2.0, __func__, __LINE__);
+    angsep = CECoordinates::AngularSeparation(test1, test2);
+    test_double(angsep.Deg(), 2.0, __func__, __LINE__);
     angsep = CECoordinates::AngularSeparation(test1_x, test1_y,
-                                              test2_x, test2_y, 
-                                              CEAngleType::DEGREES);
-    test_double(angsep, 2.0, __func__, __LINE__);
+                                              test2_x, test2_y);
+    test_double(angsep.Deg(), 2.0, __func__, __LINE__);
 
     // Test that the two coordinates are not equal
     test((test1 != test2), __func__, __LINE__);
@@ -474,7 +468,7 @@ bool test_CECoordinates::test_coords(const CECoordinates& test,
                     test.YCoordinate_Deg(), expected.YCoordinate_Deg(), 
                     (test.YCoordinate_Deg()-expected.YCoordinate_Deg())*3600.0);
         std::printf("     AngSep: %e arcsec\n", 
-                    test.AngularSeparation(expected, CEAngleType::DEGREES)*3600.0);
+                    test.AngularSeparation(expected).Deg()*3600.0);
     }
     return pass;
 }

--- a/cppephem/test/test_CENamespace.cpp
+++ b/cppephem/test/test_CENamespace.cpp
@@ -57,6 +57,7 @@ bool test_CENamespace::runtests()
     test_SeaLevelVals();
     test_Conversions();
     test_Corrections();
+    test_StrOpt();
 
     return pass();
 }
@@ -181,6 +182,35 @@ bool test_CENamespace::test_Corrections()
 
     return pass();
 }
+
+
+/**********************************************************************//**
+ * Tests the string operations
+ * @return Whether the tests are passing or not
+ *************************************************************************/
+bool test_CENamespace::test_StrOpt(void)
+{
+    // Create a string for parsing
+    std::string test1 = "hello world!";
+    test_vect(CppEphem::StrOpt::split(test1, ' '), {"hello", "world!"}, __func__, __LINE__);
+
+    // See if we can pass the vector and get the same results back
+    std::vector<std::string> test2;
+    CppEphem::StrOpt::split(test1, ' ', &test2);
+    test_vect(test2, {"hello", "world!"}, __func__, __LINE__);
+
+    // Check if we can put it back together
+    std::string test3 = CppEphem::StrOpt::join<std::string>(test2, ',');
+    test_string(test3, "hello,world!", __func__, __LINE__);
+
+    // See if we can join a vector of angle components into a legit string
+    std::vector<double> angles = {123, 34, 52, 0.542};
+    std::string angle_str = CppEphem::StrOpt::join_angle(angles, ':');
+    test_string(angle_str, "123:34:52.54200000", __func__, __LINE__);
+
+    return pass();
+}
+
 
 /**********************************************************************//**
  * Main method that actually runs the tests

--- a/cppephem/test/test_CENamespace.h
+++ b/cppephem/test/test_CENamespace.h
@@ -37,6 +37,7 @@ public:
     virtual bool test_SeaLevelVals(void);
     virtual bool test_Conversions(void);
     virtual bool test_Corrections(void);
+    virtual bool test_StrOpt(void);
 
 };
 

--- a/cppephem/test/test_CEObservation.cpp
+++ b/cppephem/test/test_CEObservation.cpp
@@ -47,9 +47,8 @@ test_CEObservation::test_CEObservation() :
     base_date_.SetReturnType(CEDateType::JD);
 
     // Set the object that will be observed
-    base_body_ = CEBody("test", 83.663, 22.0145, 
-                        CECoordinateType::ICRS, 
-                        CEAngleType::DEGREES);
+    base_body_ = CEBody("test", CEAngle::Deg(83.663), CEAngle::Deg(22.0145), 
+                        CECoordinateType::ICRS);
     
     // Put it all together
     base_obs_ = CEObservation(&base_observer_, &base_body_, &base_date_);
@@ -166,11 +165,12 @@ bool test_CEObservation::test_cache(void)
     
     // Now we setup the actual tests for observed coordinates
     // Note: these coordinates are derived from CECoordinates tests
-    CECoordinates obs_coords(35.55160709646245, 152.5681387256824,
-                             CECoordinateType::OBSERVED, CEAngleType::DEGREES);
-    CECoordinates test2(base_obs_.GetAzimuth_Deg(),
-                        base_obs_.GetZenith_Deg(),
-                        CECoordinateType::OBSERVED, CEAngleType::DEGREES);
+    CECoordinates obs_coords(CEAngle::Deg(35.55160709646245), 
+                             CEAngle::Deg(152.5681387256824),
+                             CECoordinateType::OBSERVED);
+    CECoordinates test2(base_obs_.GetAzimuth_Rad(),
+                        base_obs_.GetZenith_Rad(),
+                        CECoordinateType::OBSERVED);
 
     // Test that the coordinates update when the date is changed
     test(obs_coords == test2, __func__, __LINE__);

--- a/cppephem/test/test_CEObserver.cpp
+++ b/cppephem/test/test_CEObserver.cpp
@@ -220,25 +220,26 @@ bool test_CEObserver::test_set_atmoPars()
  *************************************************************************/
 bool test_CEObserver::test_get_obsCoords(void)
 {
-    CEBody body("North Pole", 0.0, 90.0, CECoordinateType::ICRS, CEAngleType::DEGREES);
+    CEBody body("North Pole", CEAngle::Deg(0.0), CEAngle::Deg(90.0), 
+                CECoordinateType::ICRS);
     CEDate date(CppEphem::julian_date_J2000(), CEDateType::JD);
     CECoordinates obs_coords = base_obs_.ObservedPosition(body, date);
 
     // Note that these test coordinates were derived using Astropy
     // to ensure the values returned are correct
-    CECoordinates test_coords(359.9960211433963, 90.00137453000666, 
-                              CECoordinateType::OBSERVED, CEAngleType::DEGREES);
+    CECoordinates test_coords(CEAngle::Deg(359.9960211433963), 
+                              CEAngle::Deg(90.00137453000666), 
+                              CECoordinateType::OBSERVED);
 
     // Make sure observed coordinates are near where we expect them to be
-    double angsep = CECoordinates::AngularSeparation(obs_coords, test_coords, 
-                                                     CEAngleType::RADIANS);
+    CEAngle angsep = CECoordinates::AngularSeparation(obs_coords, test_coords);
     // Make sure the accuracy is within 0.5 arcsecond
-    if (!test_lessthan(angsep, 0.5*DAS2R, __func__, __LINE__)) {
+    if (!test_lessthan(angsep.Rad(), 0.5*DAS2R, __func__, __LINE__)) {
         std::printf("date: %f\n", date.Gregorian());
         std::printf("dut1,x,y: %f sec, %e rad, %e rad\n", date.dut1(), date.xpolar(), date.ypolar());
         std::printf("Obs %s", obs_coords.print().c_str());
         std::printf("Test %s", test_coords.print().c_str());
-        std::printf("Angsep: %e deg\n", angsep * DR2D);
+        std::printf("Angsep: %e deg\n", angsep.Deg());
         std::printf("%s", base_obs_.print().c_str());
     }
 

--- a/cppephem/test/test_CEPlanet.cpp
+++ b/cppephem/test/test_CEPlanet.cpp
@@ -85,17 +85,18 @@ bool test_CEPlanet::test_construct(void)
     test(test1.GetCoordinates() == test_coord, __func__, __LINE__);
 
     // Default constructors
-    CEPlanet test2("DefaultPlanet", 123.45, 67.89, CECoordinateType::ICRS, CEAngleType::DEGREES);
+    CEPlanet test2("DefaultPlanet", CEAngle::Deg(123.45), CEAngle::Deg(67.89), 
+                   CECoordinateType::ICRS);
     test_string(test2.Name(), "DefaultPlanet", __func__, __LINE__);
-    test_double(test2.XCoordinate_Deg(), 123.45, __func__, __LINE__);
-    test_double(test2.YCoordinate_Deg(), 67.89, __func__, __LINE__);
+    test_double(test2.XCoord().Deg(), 123.45, __func__, __LINE__);
+    test_double(test2.YCoord().Deg(), 67.89, __func__, __LINE__);
     test_int(int(test2.GetCoordSystem()), int(CECoordinateType::ICRS), __func__, __LINE__);
 
     // Copy constructor
     CEPlanet test3(test2);
     test_string(test3.Name(), test2.Name(), __func__, __LINE__);
-    test_double(test3.XCoordinate_Deg(), test2.XCoordinate_Deg(), __func__, __LINE__);
-    test_double(test3.YCoordinate_Deg(), test2.YCoordinate_Deg(), __func__, __LINE__);
+    test_double(test3.XCoord().Deg(), test2.XCoord().Deg(), __func__, __LINE__);
+    test_double(test3.YCoord().Deg(), test2.YCoord().Deg(), __func__, __LINE__);
     test_int(int(test3.GetCoordSystem()), int(test2.GetCoordSystem()), __func__, __LINE__);
 
     // Copy assignment operator
@@ -123,10 +124,12 @@ bool test_CEPlanet::test_mercury(void)
 
     // Run the actual test with values derived from AstroPy
     test_planet(mercury,
-                CECoordinates(251.1840266663606371, -25.3023875289787838, 
-                              CECoordinateType::ICRS, CEAngleType::DEGREES),
-                CECoordinates(197.8036693771968260, 25.7350871794139664,
-                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
+                CECoordinates(CEAngle::Deg(251.1840266663606371), 
+                              CEAngle::Deg(-25.3023875289787838), 
+                              CECoordinateType::ICRS),
+                CECoordinates(CEAngle::Deg(197.8036693771968260), 
+                              CEAngle::Deg(25.7350871794139664),
+                              CECoordinateType::OBSERVED),
                 {-0.13721236, -0.4032437, -0.20141521},
                 {0.02137206, -0.00493223, -0.00485005});
 
@@ -148,10 +151,12 @@ bool test_CEPlanet::test_venus(void)
 
     // Run the actual test with values derived from AstroPy
     test_planet(venus,
-                CECoordinates(183.8496760951891247, 1.8722067172672485, 
-                              CECoordinateType::ICRS, CEAngleType::DEGREES),
-                CECoordinates(242.8427330437376099, 43.8958267247570220,
-                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
+                CECoordinates(CEAngle::Deg(183.8496760951891247), 
+                              CEAngle::Deg(1.8722067172672485), 
+                              CECoordinateType::ICRS),
+                CECoordinates(CEAngle::Deg(242.8427330437376099), 
+                              CEAngle::Deg(43.8958267247570220),
+                              CECoordinateType::OBSERVED),
                 {-0.72543765, -0.04893718, 0.02371176},
                 {0.00080326, -0.01849847, -0.00837267});
 
@@ -173,10 +178,12 @@ bool test_CEPlanet::test_earth(void)
 
     // Run the actual test with values derived from AstroPy
     test_planet(earth,
-                CECoordinates(101.7655134417398273, 23.0103434895188776, 
-                              CECoordinateType::ICRS, CEAngleType::DEGREES),
-                CECoordinates(89.9999999991386233, 179.9999111107912881,
-                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
+                CECoordinates(CEAngle::Deg(101.7655134417398273), 
+                              CEAngle::Deg(23.0103434895188776), 
+                              CECoordinateType::ICRS),
+                CECoordinates(CEAngle::Deg(89.9999999991386233),
+                              CEAngle::Deg(179.9999111107912881),
+                              CECoordinateType::OBSERVED),
                 {-0.18428431, 0.88477935, 0.383819},
                 {-0.01720221, -0.00290513, -0.00125952});
     
@@ -198,10 +205,12 @@ bool test_CEPlanet::test_mars(void)
 
     // Run the actual test with values derived from AstroPy
     test_planet(mars,
-                CECoordinates(359.9442433037739306, -1.5700885004650793, 
-                              CECoordinateType::ICRS, CEAngleType::DEGREES),
-                CECoordinates(106.9869245851015762, 51.3129710961485586,
-                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
+                CECoordinates(CEAngle::Deg(359.9442433037739306), 
+                              CEAngle::Deg(-1.5700885004650793), 
+                              CECoordinateType::ICRS),
+                CECoordinates(CEAngle::Deg(106.9869245851015762), 
+                              CEAngle::Deg(51.3129710961485586),
+                              CECoordinateType::OBSERVED),
                 {1.38356924, -0.0011989, -0.0378561},
                 {0.00067763, 0.01380768, 0.00631503});
 
@@ -221,8 +230,8 @@ bool test_CEPlanet::test_mars(void)
     CEPlanet mars2 = CEPlanet::Mars();
     mars2.SetAlgorithm(CEPlanetAlgo::JPL);
     mars2.UpdateCoordinates(base_date_.JD());
-    double angsep = mars.AngularSeparation(mars2, CEAngleType::DEGREES);
-    test(angsep < 0.1, __func__, __LINE__);
+    CEAngle angsep = mars.AngularSeparation(mars2);
+    test_lessthan(angsep.Deg(), 0.1, __func__, __LINE__);
 
     return pass();
 }
@@ -242,10 +251,12 @@ bool test_CEPlanet::test_jupiter(void)
 
     // Run the actual test with values derived from AstroPy
     test_planet(jupiter,
-                CECoordinates(34.3822629405528843, 12.5158780867456674, 
-                              CECoordinateType::ICRS, CEAngleType::DEGREES),
-                CECoordinates(81.1700048918871886, 103.2491992750974532, 
-                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
+                CECoordinates(CEAngle::Deg(34.3822629405528843), 
+                              CEAngle::Deg(12.5158780867456674), 
+                              CECoordinateType::ICRS),
+                CECoordinates(CEAngle::Deg(81.1700048918871886), 
+                              CEAngle::Deg(103.2491992750974532), 
+                              CECoordinateType::OBSERVED),
                 {3.99442023, 2.7334608, 1.07451899},
                 {-0.00455544, 0.00587705, 0.00263009});
     
@@ -267,10 +278,12 @@ bool test_CEPlanet::test_saturn(void)
 
     // Run the actual test with values derived from AstroPy
     test_planet(saturn,
-                CECoordinates(43.9734819060061355, 14.3451097907081060, 
-                              CECoordinateType::ICRS, CEAngleType::DEGREES),
-                CECoordinates(75.7370064470109696, 117.5753277202141760, 
-                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
+                CECoordinates(CEAngle::Deg(43.9734819060061355), 
+                              CEAngle::Deg(14.3451097907081060), 
+                              CECoordinateType::ICRS),
+                CECoordinates(CEAngle::Deg(75.7370064470109696),
+                              CEAngle::Deg(117.5753277202141760), 
+                              CECoordinateType::OBSERVED),
                 {6.39746262, 6.17262105, 2.2735304},
                 {-0.00429156, 0.00350834, 0.00163369});
     
@@ -292,10 +305,12 @@ bool test_CEPlanet::test_uranus(void)
 
     // Run the actual test with values derived from AstroPy
     test_planet(uranus,
-                CECoordinates(319.0662412483117691, -16.5756054581048744, 
-                              CECoordinateType::ICRS, CEAngleType::DEGREES),
-                CECoordinates(116.9533213948411401, 40.2264403677069211, 
-                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
+                CECoordinates(CEAngle::Deg(319.0662412483117691), 
+                              CEAngle::Deg(-16.5756054581048744), 
+                              CECoordinateType::ICRS),
+                CECoordinates(CEAngle::Deg(116.9533213948411401), 
+                              CEAngle::Deg(40.2264403677069211), 
+                              CECoordinateType::OBSERVED),
                 {14.42492523, -12.50957402, -5.6830779},
                 {0.00269067, 0.00244776, 0.00103396});
     
@@ -317,10 +332,12 @@ bool test_CEPlanet::test_neptune(void)
 
     // Run the actual test with values derived from AstroPy
     test_planet(neptune,
-                CECoordinates(306.1731137010386306, -19.0396553491478997, 
-                              CECoordinateType::ICRS, CEAngleType::DEGREES),
-                CECoordinates(129.5362400208609870, 31.1291412849027509, 
-                              CECoordinateType::OBSERVED, CEAngleType::DEGREES),
+                CECoordinates(CEAngle::Deg(306.1731137010386306), 
+                              CEAngle::Deg(-19.0396553491478997), 
+                              CECoordinateType::ICRS),
+                CECoordinates(CEAngle::Deg(129.5362400208609870),
+                              CEAngle::Deg(31.1291412849027509), 
+                              CECoordinateType::OBSERVED),
                 {16.80489053, -22.98266171, -9.82533257},
                 {0.00258607, 0.00165554, 0.00061312});
 
@@ -347,17 +364,16 @@ bool test_CEPlanet::test_planet(const CEPlanet&            test_planet,
     std::string func_name = std::string(__func__) + " (" + test_planet.Name() + ")";
 
     // Test ICRS coordinates
-    CECoordinates icrs_coords(test_planet.XCoordinate_Rad(),
-                              test_planet.YCoordinate_Rad(),
-                              CECoordinateType::ICRS,
-                              CEAngleType::RADIANS);    
+    CECoordinates icrs_coords(test_planet.XCoord(),
+                              test_planet.YCoord(),
+                              CECoordinateType::ICRS);    
     if (!test(icrs_coords == true_icrs, func_name, __LINE__)) {
         // Print information about the coordinates
         std::printf("   %s   %s", icrs_coords.print().c_str(), true_icrs.print().c_str());
-        std::printf("   X-diff: %f arcsec\n", (icrs_coords.XCoordinate_Deg()-true_icrs.XCoordinate_Deg())*3600.0);
-        std::printf("   Y-diff: %f arcsec\n", (icrs_coords.YCoordinate_Deg()-true_icrs.YCoordinate_Deg())*3600.0);
+        std::printf("   X-diff: %f arcsec\n", (icrs_coords.XCoord().Deg()-true_icrs.XCoord().Deg())*3600.0);
+        std::printf("   Y-diff: %f arcsec\n", (icrs_coords.YCoord().Deg()-true_icrs.YCoord().Deg())*3600.0);
     }
-    std::printf("      AngSep ICRS: %e arcsec\n", icrs_coords.AngularSeparation(true_icrs, CEAngleType::DEGREES)*3600.0);
+    std::printf("      AngSep ICRS: %e arcsec\n", icrs_coords.AngularSeparation(true_icrs).Deg()*3600.0);
 
     // Test observed coordinates
     CECoordinates obs_coords = test_planet.ObservedCoords(base_date_, 
@@ -366,10 +382,10 @@ bool test_CEPlanet::test_planet(const CEPlanet&            test_planet,
     if (!test(obs_coords == true_obs, func_name, __LINE__)) {
         // Print information about the coordinates
         std::printf("   %s   %s", obs_coords.print().c_str(), true_obs.print().c_str());
-        std::printf("   X-diff: %f arcsec\n", (obs_coords.XCoordinate_Deg()-true_obs.XCoordinate_Deg())*3600.0);
-        std::printf("   Y-diff: %f arcsec\n", (obs_coords.YCoordinate_Deg()-true_obs.YCoordinate_Deg())*3600.0);
+        std::printf("   X-diff: %f arcsec\n", (obs_coords.XCoord().Deg()-true_obs.XCoord().Deg())*3600.0);
+        std::printf("   Y-diff: %f arcsec\n", (obs_coords.YCoord().Deg()-true_obs.YCoord().Deg())*3600.0);
     }
-    std::printf("      AngSep Obs : %e arcsec\n", obs_coords.AngularSeparation(true_obs, CEAngleType::DEGREES)*3600.0);
+    std::printf("      AngSep Obs : %e arcsec\n", obs_coords.AngularSeparation(true_obs).Deg()*3600.0);
 
     // Update the tolerance
     double tol_old = DblTol();

--- a/gen_coverage.sh
+++ b/gen_coverage.sh
@@ -19,6 +19,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "clang" ]] ; then
     # Run all of the individual tests with output
     # NOTE: Make sure the coverage files end with '.profraw'
     echo "Running coverage"
+    LLVM_PROFILE_FILE="${outdir}/CEAngle.profraw"       ./build/bin/test_CEAngle
     LLVM_PROFILE_FILE="${outdir}/CEBody.profraw"        ./build/bin/test_CEBody
     LLVM_PROFILE_FILE="${outdir}/CECoordinates.profraw" ./build/bin/test_CECoordinates
     LLVM_PROFILE_FILE="${outdir}/CEDate.profraw"        ./build/bin/test_CEDate
@@ -85,6 +86,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "clang" ]] ; then
     # Generate the output text to be read by sonar-scanner
     llvm-cov show \
         -instr-profile ${merge_report} \
+        -object ./build/bin/test_CEAngle \
         -object ./build/bin/test_CEBody \
         -object ./build/bin/test_CECoordinates \
         -object ./build/bin/test_CEDate \

--- a/test/include/CETestSuite.h
+++ b/test/include/CETestSuite.h
@@ -95,6 +95,10 @@ protected:
                    const std::vector<double>& expected,
                    const std::string& function = FUNC_DEFAULT,
                    const int&         line     = LINE_DEFAULT);
+    bool test_vect(const std::vector<std::string>& value,
+                   const std::vector<std::string>& expected,
+                   const std::string&              function = FUNC_DEFAULT,
+                   const int&                      line     = LINE_DEFAULT);
 
     template<class T>
     bool test_lessthan_(const T& value,

--- a/test/include/CETestSuite.h
+++ b/test/include/CETestSuite.h
@@ -68,6 +68,10 @@ protected:
     virtual bool test(bool  test_success, 
                       const std::string& function = FUNC_DEFAULT,
                       const int&         line     = LINE_DEFAULT);
+    virtual bool test(bool  test_success, 
+                      const std::string& message,
+                      const std::string& function = FUNC_DEFAULT,
+                      const int&         line     = LINE_DEFAULT);
     virtual bool test_double(const double&      value, 
                              const double&      expected,
                              const std::string& function = FUNC_DEFAULT,
@@ -121,7 +125,7 @@ protected:
                           const int&         line);
 
     virtual void update_pass(const bool& test_passed);
-    
+
 private:
 
     /****** VARIABLES ******/

--- a/test/src/CETestSuite.cpp
+++ b/test/src/CETestSuite.cpp
@@ -272,6 +272,44 @@ bool CETestSuite::test_vect(const std::vector<double>& value,
 
 
 /**********************************************************************//**
+ * Return whether two vector<double>'s contain equivalent values
+ *
+ * @param[in] value         Value to be tested
+ * @param[in] expected      Expected value to test against
+ * @param[in] function      Name of the function where test was run
+ * @param[in] line          Line where test was run
+ * @return Whether value and expected are the same
+ *************************************************************************/
+bool CETestSuite::test_vect(const std::vector<std::string>& value,
+                            const std::vector<std::string>& expected,
+                            const std::string& function,
+                            const int&         line)
+{
+    bool isMatch = true;
+    if (value.size() == expected.size()) {
+        for (int i=0; i<value.size(); i++) {
+            if (value[i] != expected[i]) {
+                log_failure("VECTOR values at index "+std::to_string(i)+" " +
+                            "are NOT equal (input:\"" + value[i] + "\", " +
+                            "expect:\"" + expected[i] + "\")", function, line);
+                isMatch = false;
+            }
+        }
+
+        // If there is a match, then we consider the vectors to be equal
+        if (isMatch) {
+            log_success("VECTOR values and lengths ARE equal.", function, line);
+        }
+    } else {
+        log_failure("VECTOR lengths are NOT equal.", function, line);
+    }
+
+    update_pass(isMatch);
+    return isMatch;
+}
+
+
+/**********************************************************************//**
  * Return whether a value is less than a specified value
  *
  * @param[in] value         Value to be tested

--- a/test/src/CETestSuite.cpp
+++ b/test/src/CETestSuite.cpp
@@ -73,6 +73,34 @@ bool CETestSuite::test(bool  test_success,
 /**********************************************************************//**
  * Return whether value is within a specified tolerance of 'expected'
  *
+ * @param[in] test_success  A simple boolean for whether a test passed
+ * @param[in] message       Message for the test
+ * @param[in] function      Name of the function where test was run
+ * @param[in] line          Line where test was run
+ * @return The same value as @p test_success
+ *************************************************************************/
+bool CETestSuite::test(bool  test_success, 
+                       const std::string& message,
+                       const std::string& function,
+                       const int&         line)
+{
+    // Values equal within tolerance
+    if (test_success) {
+        log_success(message + " (SUCCEEDED)", function, line);
+    } 
+    // Values not within tolerance
+    else {
+        log_failure(message + " (FAILED)", function, line);
+    }
+
+    update_pass(test_success);
+    return test_success;
+}
+
+
+/**********************************************************************//**
+ * Return whether value is within a specified tolerance of 'expected'
+ *
  * @param[in] value         Value to be tested
  * @param[in] expected      Expected value to test against
  * @param[in] function      Name of the function where test was run


### PR DESCRIPTION
This PR adds the CEAngle class, resolving issue #24. 
### Overview of `CEAngle`
The `CEAngle` class makes it possible to construct an angle object from either a degree, radian, string, or vector representing {hours, minutes, seconds} or {degrees, arcmin, arcsec}. It stores the angle in radians and can be directly interpreted as an angle in radians. This allows it to be internally passed directly to SOFA methods, which typically use radians for angles.

Methods are also provided for returning the angle in various formats:
```cpp
CEAngle angle = CEAngle::Deg(22.0145);
std::vector<double> hms_vect = angle.HmsVect();  // {1,28,3,0.48}
std::vector<double> dms_vect = angle.DmsVect();  // {22,0,52,0.2}
std::string hms_str = angle.HmsStr();    // "01:28:03.48000000"
std::string dms_str = angle.DmsStr('_'); // "22_00_52.20000000"
```

### Implications for the `CECoordinates`
The `CECoordinates` class now takes CEAngle objects in its constructors and in the `AngularSeparation` method. It can still be constructed from doubles representing the angles in radians or by using the static CEAngle methods `Deg`, `Rad`, `Hms`, or `Dms` that return a CEAngle object derived from an appropriately formatted angle. For example, to construct an angle from HMS, DMS strings you would call (note the CEAngleType is no longer required):
```cpp
// Crab nebula in RA,Dec as degrees ...
CECoordinates crab1(CEAngle::Deg(83.633), CEAngle::Deg(22.0145), CECoordinateType::ICRS);
// ... or RA, Dec in hours:minutes:sec and deg:arcmin:arcsec format
std::string hms("5:34:31.94");
std::string dms("22:0:52.2");
CECoordinates crab2(CEAngle::Hms(hms), CEAngle::Dms(dms), CECoordinateType::ICRS);
```

Note that the string format can also have a user defined delimiter:
```cpp
// Crab Nebula RA, Dec in hours:minutes:sec and deg:arcmin:arcsec format
std::string hms("5,34,31.94"); 
std::string dms("22,0,52.2");
CECoordinates coord(CEAngle::Hms(hms, ','), CEAngle::Dms(dms, ','), CECoordinateType::ICRS);
```
The x,y coordinates are also stored as CEAngle objects and `CECoordinates::XCoord` and `CECoordinates::YCoord` return these angles as CEAngles allowing direct use of the CEAngle methods for extracting the angle in your preferred format.