### PR TITLE
Add exec directory to coverage checks

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v1.2.99 : HEAD
+ - Add executable 'convcoord' for converting between any coordinate systems
+ - Add support for Ecliptic coordinates [#18]
  - Update SOFA to latest release (2019-07-22) [#27]
  - Deprecate CECoordinates class and make all classes and executables use CESkyCoord class
  - Add new CESkyCoord class as a simplified version of CECoordinates class [#20]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,7 @@ sonar.links.issue=https://github.com/Jvinniec/CppEphem/issues
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # This property is optional if sonar.modules is set. 
-sonar.sources=cppephem/src,cppephem/include
+sonar.sources=cppephem/src,cppephem/include,cppephem/exec
 sonar.cxx.includeDirectories=cppephem/include
 sonar.cxx.suffixes.sources=.cxx,.cpp,.cc,.c,.h,.hpp
 sonar.cfamily.llvm-cov.reportPath=./build/coverage_report/coverage_report.txt


### PR DESCRIPTION
The `exec` directory was not being checked in the coverage statistics. This has been fixed.